### PR TITLE
Add ability to pass defaultValue to select field card

### DIFF
--- a/src/molecules/formfields/SelectField/index.js
+++ b/src/molecules/formfields/SelectField/index.js
@@ -31,7 +31,8 @@ function SelectField( props ) {
     focused,
     type,
     input,
-    tooltip
+    tooltip,
+    defaultValue
   } = props;
 
   return (
@@ -54,17 +55,21 @@ function SelectField( props ) {
         </label>
       }
 
-      <div className={styles.selectbox}>
-        <select
-          required
-          className={styles.select}
-          id={forProp}
-          {...input}
-        >
-          { placeholder && renderPlaceholder( placeholder, styles.option ) }
-          { selectOptions.map(renderOptions) }
-        </select>
-      </div>
+      { defaultValue ?
+        <div className={styles.select}>{defaultValue}</div>
+        :
+        <div className={styles.selectbox}>
+          <select
+            required
+            className={styles.select}
+            id={forProp}
+            {...input}
+          >
+            { placeholder && renderPlaceholder( placeholder, styles.option ) }
+            { selectOptions.map(renderOptions) }
+          </select>
+        </div>
+      }
     </div>
   );
 }
@@ -101,7 +106,7 @@ SelectField.propTypes = {
   selectOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ])
-  })).isRequired,
+  })),
 
   /**
    * defines type of select field
@@ -114,7 +119,11 @@ SelectField.propTypes = {
   /**
    * Content for tooltip
    */
-  tooltip: PropTypes.node
+  tooltip: PropTypes.node,
+  /**
+   * Default / non-changeable value
+   */
+  defaultValue: PropTypes.string
 };
 
 SelectField.defaultProps = {

--- a/src/organisms/cards/SelectCard/index.js
+++ b/src/organisms/cards/SelectCard/index.js
@@ -16,17 +16,20 @@ function SelectCard( props ) {
     footerText,
     linkUrl,
     onClick,
-    input
+    input,
+    defaultValue
   } = props;
 
   return (
     <div className={classnames( styles.select, className )}>
+
       <SelectField
         type='select-card'
         label={label}
         placeholder={placeholder}
         selectOptions={selectOptions}
         input={input}
+        defaultValue={defaultValue}
       />
 
       <footer className={styles.footer}>
@@ -78,12 +81,16 @@ SelectCard.propTypes = {
   /**
    * array of select options for select field
    */
-  selectOptions: PropTypes.array.isRequired,
+  selectOptions: PropTypes.array,
 
   /**
    * Redux Form input object; pass any variables necessary for input change here
    */
-  input: PropTypes.object
+  input: PropTypes.object,
+  /**
+   * Default / non-changeable value for the select field
+   */
+  defaultValue: PropTypes.string
 };
 
 export default SelectCard;


### PR DESCRIPTION
@policygenius/front-end 👀  pls

allows us to pass `defaultValue` into select card or select field, which will render only that value in place of options. The specific use case for this is the 'Loss of use' field https://app.zeplin.io/project/58e6498f59f26ca94d348983/screen/59024c98ed2f9e224a85820e
which will be a pre-determined value, depending on personal property coverage