### PR TITLE
Fix selectcard field mobile font size

### DIFF
--- a/src/molecules/formfields/shared/formfields.module.scss
+++ b/src/molecules/formfields/shared/formfields.module.scss
@@ -216,7 +216,7 @@ $checkbox-border-color: color('neutral-5');
   }
 
   .select {
-    @include typography-3(false);
+    @include typography-5(false);
     padding: ru(.5) ru(1);
     letter-spacing: .2px;
     pointer-events: all;
@@ -224,6 +224,10 @@ $checkbox-border-color: color('neutral-5');
     &:invalid {
       @include typography-3(false);
       color: color('brand-2');
+    }
+
+    @media #{$medium-up} {
+      @include typography-3(false);
     }
   }
 }


### PR DESCRIPTION
@drewdrewthis @cisacke the tiniest CR ever

Fixes select card fields font size on mobile.

See zeplin for comparison: https://app.zeplin.io/project/58e6498f59f26ca94d348983/screen/59024c98ed2f9e224a85820e