### PR TITLE
Add Textlockup H

### DIFF
--- a/src/molecules/TextLockup/Readme.md
+++ b/src/molecules/TextLockup/Readme.md
@@ -75,3 +75,24 @@ TextLockup Example - Type G:
       subheader='Subheader'
     />
 ```
+TextLockup Example - Type H:
+
+```example
+    <TextLockup
+      variant='H'
+      header='Header'
+    >
+      <TextComponent
+        type={6}
+      >
+        Subheader 1
+      </TextComponent>
+
+      <TextComponent
+        type={6}
+      >
+        Subheader 2
+      </TextComponent>
+    </TextLockup>
+
+```

--- a/src/molecules/TextLockup/index.js
+++ b/src/molecules/TextLockup/index.js
@@ -134,6 +134,29 @@ function TextLockup( props ) {
           </div>
         );
 
+      case 'H':
+        return (
+          <div className={styles[variant]}>
+            <TextComponent
+              className={styles['header']}
+              type={7}
+              light
+            >
+              { header }
+            </TextComponent>
+
+            {
+              React.Children.map(children, child =>
+                React.cloneElement(
+                  child,
+                  { className: styles['subheader'] }
+                )
+              )
+            }
+          </div>
+
+        );
+
       default:
         return (
           <div className={styles[variant]}>

--- a/src/molecules/TextLockup/text-lockups.module.scss
+++ b/src/molecules/TextLockup/text-lockups.module.scss
@@ -68,7 +68,7 @@ $subheader-color: color('neutral-4');
   }
 }
 
-.G {
+.G, .H {
   .header {
     color: color('neutral-3');
   }

--- a/src/organisms/cards/RadioCard/index.js
+++ b/src/organisms/cards/RadioCard/index.js
@@ -51,7 +51,7 @@ function RadioCard(props) {
           className
         )
       }
-      {...omit(input, ['value', 'onClick'])}
+      {...omit(input, [ 'value', 'onClick' ])}
       onClick={() => input.onChange(radioValue)}
       id={`radio-${input.name}`}
       key={`radio-${radioValue}`}


### PR DESCRIPTION
@drewdrewthis @cisacke @patrickkim 

Adds variant H for a TextLockup with multiple subheaders

See [zeplin](https://app.zeplin.io/project/58e6498f59f26ca94d348983/screen/590cb5fba5958418448f8c8a) - Payment Details `PlaybackCard`