### PR TITLE
Change footer prop types

### DIFF
--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -98,9 +98,9 @@ Footer.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Formatted Contact phone number.
+   * Formatted Contact phone number. Can be wrapped in additional markup
    */
-  phoneNumber: PropTypes.string,
+  phoneNumber: PropTypes.node,
   /**
    * Function to trigger chat.
    */


### PR DESCRIPTION
It requires exactly a string, but in life, we need to pass a span or something, so it's warning us about prop-types in the console