### PR TITLE
Add tooltip to TextField label & CreditCardInput CCV

### DIFF
--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -35,11 +35,12 @@ class Tooltip extends React.Component {
       className,
       left,
       right,
+      onClick,
     } = this.props;
 
     return (
       <span
-        onClick={this.openModal}
+        onClick={onClick || this.openModal}
         className={classnames(
           styles['tooltip-wrapper'],
           className
@@ -48,7 +49,7 @@ class Tooltip extends React.Component {
         <Icon icon='questionMark' className={styles['tooltip']} />
         <span
           className={classnames(
-            styles['hover-message'],
+            children && styles['hover-message'],
             left && styles['left'],
             right && styles['right'],
           )}
@@ -86,6 +87,10 @@ Tooltip.propTypes = {
    * render right-side variant
    */
   right: PropTypes.bool,
+  /**
+   * onClick will override the default `openModal` click handler
+   */
+  onClick: PropTypes.func,
 };
 
 export default Tooltip;

--- a/src/molecules/formfields/CreditCardField/Readme.md
+++ b/src/molecules/formfields/CreditCardField/Readme.md
@@ -22,6 +22,7 @@ CreditCardField Example:
       securityCode={
         <TextField
           placeholder='3/4 Digit Security Code'
+          inputTooltip={() => alert('input tooltip clicked')}
           noBaseStyle
         />
       }

--- a/src/molecules/formfields/TextField/Readme.md
+++ b/src/molecules/formfields/TextField/Readme.md
@@ -58,7 +58,7 @@ Text field - phone number example:
   <TextField
     label='Phone Number'
     placeholder='In case of emergency'
-    tooltip={"I'm a tooltip"}
+    tooltip={() => alert("I'm a tooltip")}
     input={{
       value: state.value,
       onChange: event => setState({ value: event.target.value })
@@ -74,7 +74,6 @@ Text field - secure:
   <TextField
     label='Phone Number'
     placeholder='In case of emergency'
-    tooltip={"I'm a tooltip"}
     input={{
       value: state.value,
       onChange: event => setState({ value: event.target.value })

--- a/src/molecules/formfields/TextField/index.js
+++ b/src/molecules/formfields/TextField/index.js
@@ -4,9 +4,18 @@ import InputMask from 'react-input-mask';
 import classnames from 'classnames';
 
 import Icon from 'atoms/Icon';
+import Tooltip from 'atoms/Tooltip';
 import ErrorMessage from 'atoms/ErrorMessage';
 
 import styles from './text_field.module.scss';
+
+function renderTooltip(tooltip, className) {
+  if (typeof tooltip === 'string') {
+    return <Tooltip className={styles[className]}>{tooltip}</Tooltip>;
+  }
+
+  return <Tooltip className={styles[className]} onClick={tooltip} />;
+}
 
 function TextField( props ) {
   const {
@@ -20,7 +29,9 @@ function TextField( props ) {
     noBaseStyle,
     placeholder,
     secure,
-    id
+    id,
+    tooltip,
+    inputTooltip,
   } = props;
 
   const classes = [
@@ -39,28 +50,31 @@ function TextField( props ) {
           <div className={classnames(styles['header'])}>
             <label className={styles['label']} htmlFor={htmlFor}>{ label }</label>
             { secure && <Icon className={styles['icon-lock']} icon='lock' /> }
+            { tooltip && renderTooltip(tooltip, 'tooltip') }
           </div>
         }
-
-        { mask ?
-          <InputMask
-            className={styles['input']}
-            type='text'
-            placeholder={placeholder}
-            mask={mask}
-            maskChar={maskChar}
-            id={id}
-            {...input}
-          />
-          :
-          <input
-            className={styles['input']}
-            type='text'
-            placeholder={placeholder}
-            id={id}
-            {...input}
-          />
-        }
+        <span>
+          { mask ?
+            <InputMask
+              className={styles['input']}
+              type='text'
+              placeholder={placeholder}
+              mask={mask}
+              maskChar={maskChar}
+              id={id}
+              {...input}
+            />
+            :
+            <input
+              className={styles['input']}
+              type='text'
+              placeholder={placeholder}
+              id={id}
+              {...input}
+            />
+          }
+          {inputTooltip && renderTooltip(inputTooltip, 'input-tooltip')}
+        </span>
       </div>
 
       <ErrorMessage
@@ -125,6 +139,20 @@ TextField.propTypes = {
    * id added to the `input` node
    */
   id: PropTypes.string,
+  /**
+   * either a handler for clicking the tooltip, or text to go in the tooltip for the label
+   */
+  tooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+  ]),
+  /**
+   * either a handler for clicking the tooltip, or text to go in the tooltip for the input
+   */
+  inputTooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+  ]),
 };
 
 TextField.defaultProps = {

--- a/src/molecules/formfields/TextField/text_field.module.scss
+++ b/src/molecules/formfields/TextField/text_field.module.scss
@@ -24,6 +24,17 @@
 
 .input {
   @extend %field;
+  width: 100%;
+}
+
+.tooltip {
+  margin-left: auto;
+}
+
+.input-tooltip {
+  position: absolute;
+  right: ru(1.25);
+  bottom: ru(1.5);
 }
 
 input[type='text'] {


### PR DESCRIPTION
For AC on [this ticket](https://www.pivotaltracker.com/story/show/145950051) - basically just need to allow for a tooltip in both the `TextField` input & label that takes onClick handler. I also added the ability to make it a regular tooltip with text, since that seems a likely use case in the future.