### PR TITLE
apiKey should be key

### DIFF
--- a/src/organisms/cards/StaticMapCard/index.js
+++ b/src/organisms/cards/StaticMapCard/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
 import classnames from 'classnames';
 import styles from './static_map_card.module.scss';
 
@@ -16,9 +17,10 @@ function mapUrl(mapOptions) {
 
   if (!mapOptions.apiKey) return baseUrl;
 
-  const mapOptionsString = toQueryString(mapOptions);
+  const mapOptionsString = toQueryString(omit(mapOptions, 'apiKey'));
+  const mapStringWithKey = `${mapOptionsString}&key=${encodeURIComponent(mapOptions.apiKey)}`;
 
-  return baseUrl + mapOptionsString;
+  return baseUrl + mapStringWithKey;
 }
 
 function StaticMapCard(props) {


### PR DESCRIPTION
static maps is expecting the apiKey to be `key` - also happens to be a reserved prop name which is why I didn't change the prop to `key`