### PR TITLE
Fix Hide component for xxLarge screens

### DIFF
--- a/src/wrappers/Hide/hide.module.scss
+++ b/src/wrappers/Hide/hide.module.scss
@@ -3,7 +3,7 @@ $screens: (
   $medium-only: medium,
   $large-only: large,
   $xlarge-only: xLarge,
-  $xxlarge-only: xxLarge
+  $xxlarge-up: xxLarge
 );
 
 @each $screenSize, $className in $screens {


### PR DESCRIPTION
@cisacke super quick PR

Apparently, `xxlarge-only` does not work? I didn't want to spend time investigating, but `xxlarge-up` should be a good substitute anyway