### PR TITLE
change unit font size and remove onClick from select field input

### DIFF
--- a/src/molecules/formfields/SelectField/index.js
+++ b/src/molecules/formfields/SelectField/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import omit from 'lodash/omit';
 
 import Tooltip from 'atoms/Tooltip';
 import ErrorMessage from 'atoms/ErrorMessage';
@@ -66,7 +67,7 @@ function SelectField( props ) {
               className={styles['select']}
               id={forProp}
               required
-              {...input}
+              {...(omit(input, 'onClick'))}
             >
               { placeholder && renderPlaceholder(placeholder, styles['option'] ) }
               { renderSelectOptions(selectOptions) }

--- a/src/templates/CheckOut/Readme.md
+++ b/src/templates/CheckOut/Readme.md
@@ -4,7 +4,7 @@ Checkout Example:
     const sampleOptions = [ { label: 'Select your home type', value: -1 } ];
 
     <CheckOut
-      totalCost={{ curr: '$', value: 100, unit: 'mo' }}
+      totalCost={{ curr: '$', value: 100, unit: ' due today' }}
       sidebar={<div>This is sidebar</div>}
       footer={
         <Footer

--- a/src/templates/CheckOut/index.js
+++ b/src/templates/CheckOut/index.js
@@ -101,7 +101,7 @@ function CheckOut(props) {
                   <Col className={styles['cost-price']}>
                     { curr && <sup>{curr}</sup> }
                     { value }
-                    { unit && <small>{unit}</small> }
+                    { unit && <Text type={7} tag='span'>{unit}</Text> }
                   </Col>
                 </Layout>
               </Col>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,8 +2185,8 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     sha.js "^2.4.8"
 
 create-react-class@^15.5.2:
-  version "15.5.3"
-  resolved "https://registry.npmjs.org/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -2818,7 +2818,7 @@ electron-to-chromium@^1.2.7:
 
 element-class@^0.2.0:
   version "0.2.2"
-  resolved "https://registry.npmjs.org/element-class/-/element-class-0.2.2.tgz#9d3bbd0767f9013ef8e1c8ebe722c1402a60050e"
+  resolved "https://registry.yarnpkg.com/element-class/-/element-class-0.2.2.tgz#9d3bbd0767f9013ef8e1c8ebe722c1402a60050e"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -3252,7 +3252,7 @@ eventemitter3@1.x.x:
 
 eventemitter3@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
 
 events@^1.0.0, events@~1.1.0:
   version "1.1.1"
@@ -3330,7 +3330,7 @@ executable@^1.0.0:
 
 exenv@1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz#3835f127abf075bfe082d0aed4484057c78e3c89"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.0.tgz#3835f127abf075bfe082d0aed4484057c78e3c89"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -7444,7 +7444,7 @@ performance-now@^0.2.0:
 
 performance-now@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -8098,7 +8098,7 @@ querystringify@~1.0.0:
 
 raf@^3.0.0:
   version "3.3.2"
-  resolved "https://registry.npmjs.org/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
   dependencies:
     performance-now "^2.1.0"
 
@@ -8141,8 +8141,8 @@ rc@^1.0.1, rc@^1.1.0, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7, rc@~1.1.6:
     strip-json-comments "~2.0.1"
 
 "react-addons-shallow-compare@^0.14.2 || ^15.0.0":
-  version "15.5.2"
-  resolved "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.5.2.tgz#7cb0ee7acc8d7c93fcc202df0bf47ba916a7bdad"
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.0.tgz#b7a4e5ff9f2704c20cf686dd8a05dd08b26de252"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
@@ -8195,6 +8195,10 @@ react-docgen@^2.15.0:
     node-dir "^0.1.10"
     recast "^0.11.5"
 
+react-dom-factories@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.0.tgz#f43c05e5051b304f33251618d5bc859b29e46b6d"
+
 react-dom@^15.5.4:
   version "15.5.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
@@ -8226,14 +8230,15 @@ react-input-mask@^0.8.0:
   resolved "https://registry.npmjs.org/react-input-mask/-/react-input-mask-0.8.0.tgz#c8243004f2a43a4b6d5add380f0a5d68d9be806f"
 
 react-modal@^1.7.7:
-  version "1.7.7"
-  resolved "https://registry.npmjs.org/react-modal/-/react-modal-1.7.7.tgz#70205f51c58708c487aff681ba3fed7946e391d9"
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.9.7.tgz#07ef56790b953e3b98ef1e2989e347983c72871d"
   dependencies:
     create-react-class "^15.5.2"
     element-class "^0.2.0"
     exenv "1.2.0"
     lodash.assign "^4.2.0"
     prop-types "^15.5.7"
+    react-dom-factories "^1.0.0"
 
 react-stickynode@^1.3.1:
   version "1.3.1"
@@ -9808,7 +9813,7 @@ subarg@^1.0.0:
 
 subscribe-ui-event@^1.0.0:
   version "1.0.14"
-  resolved "https://registry.npmjs.org/subscribe-ui-event/-/subscribe-ui-event-1.0.14.tgz#c506104bc35c7abb762eb347b595442a2567267f"
+  resolved "https://registry.yarnpkg.com/subscribe-ui-event/-/subscribe-ui-event-1.0.14.tgz#c506104bc35c7abb762eb347b595442a2567267f"
   dependencies:
     eventemitter3 "^2.0.0"
     lodash "^4.0.0"


### PR DESCRIPTION
@jmcolella 👀  please -- I noticed a bug in renters where you can't change the ppc select card field because it opens the modal when you click on the select field. I think this is because `onClick` is getting passed to both `SelectCard` and `SelectField` through `input`, so the whole field is clickable. Couldn't get symlink to work because of the react-modal issue, but I think this will fix it. Also changed the font size of something on the checkout as part of AC on [this ticket](https://www.pivotaltracker.com/story/show/145686023)