### PR TITLE
Update layout spacer and fix nav spacing

### DIFF
--- a/src/atoms/Layout/layout.module.scss
+++ b/src/atoms/Layout/layout.module.scss
@@ -1,5 +1,6 @@
 $gutter-width: ru(.25);
 $border: 1px solid color('neutral-6');
+$spacer-base: .25;
 
 @mixin g-unit($cols: 1, $total-col-count: 12) {
   $width: calc( ( #{$cols} / #{$total-col-count} ) * 100%);
@@ -116,6 +117,18 @@ $border: 1px solid color('neutral-6');
   }
 
   &-xLarge {
+    margin-bottom: ru(6);
+  }
+
+  @for $i from 1 through 10 {
+    &-#{$i} { margin-bottom: ru($spacer-base * $i); }
+  }
+
+  &-11 {
+    margin-bottom: ru(3);
+  }
+
+  &-12 {
     margin-bottom: ru(6);
   }
 }

--- a/src/templates/Navigator/Readme.md
+++ b/src/templates/Navigator/Readme.md
@@ -97,7 +97,11 @@ Navigator Example:
 
           <Spacer xSmall />
 
-          <Button variant='action'>Continue</Button>
+          <Col
+            bottomSpacing={0}
+          >
+            <Button variant='action'>Continue</Button>
+          </Col>
         </Layout>
       </form>
 

--- a/src/templates/Navigator/index.js
+++ b/src/templates/Navigator/index.js
@@ -49,7 +49,7 @@ function Navigator(props) {
                 <Sticky
                   enabled
                   top={36}
-                  bottomBoundary='#sticky-bottom'
+                  bottomBoundary={1270}
                   activeClass={styles['sticky']}
                 >
                   <Icon icon='pgLogo' className={styles['logo']} />

--- a/src/templates/Navigator/navigator.module.scss
+++ b/src/templates/Navigator/navigator.module.scss
@@ -152,13 +152,21 @@ $main-section-padding: ru(1.5);
 
   .main-col,
   .right-rail {
-    padding-top: ru(1.5);
+    padding-top: ru(1);
     margin-bottom: ru(2);
   }
 
   .sticky {
     @include sticky-disable;
   }
+
+  /* stylelint-disable */
+  :global {
+    .sticky-outer-wrapper {
+      @include sticky-disable;
+    }
+  }
+  /* stylelint-enable */
 }
 
 @media #{$medium-only} {
@@ -174,7 +182,7 @@ $main-section-padding: ru(1.5);
   }
 
   .step-progress {
-    margin-bottom: ru(3);
+    margin-bottom: ru(3.5);
   }
 }
 
@@ -210,7 +218,7 @@ $main-section-padding: ru(1.5);
 
   .main-layout {
     max-width: $main-section-width;
-    padding: $main-section-padding;
+    padding: $main-section-padding $main-section-padding ru(6) $main-section-padding;
   }
 
 


### PR DESCRIPTION
@cisacke CR please

- Adds `spacer` numbering to `Layout`/`Col` `bottomSpacing` prop
- Fixes issue where pg logo and rail text would appear over main CTA on tablet/mobile
- Fixes spacing between last element in main layout and footer
- Fixes spacing between first element in main layout and breadcrumbs

See [this PT ticket](https://www.pivotaltracker.com/story/show/146872459) for specifics on spacing