### PR TITLE
Add height and flex to html/body nodes

### DIFF
--- a/src/assets/stylesheets/base_styles/_pg_normalize.scss
+++ b/src/assets/stylesheets/base_styles/_pg_normalize.scss
@@ -11,7 +11,14 @@ a:hover {
   cursor: pointer;
 }
 
+html,
 body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
   font-family: $font-family-sans-serif;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
@cisacke @patrickkim @drewdrewthis 

We have an issue in renters (and in a lot of our other flows), where the footer of the nav does not extend to the bottom of the page. It seems that the issue is that the child of `body`, in renters and other flows, does not have a height associated with it.

By defaulting `body` and `html` to 100% height, we are giving a basis for the first child height. By using `flex` in `body`, we are able to make that child grow to the body, from what I understand of `flex`.

I'm sure there is a reason why we didn't give a height to both `html` and `body` to begin with. Please let me know if there is a better way to fix this problem. I guess the big issue with making `html` and `body` 100% height is that they only take the height of the viewport and the content within extends beyond.