### PR TITLE
change onBlur handler for cc field

### DIFF
--- a/src/molecules/formfields/CreditCardField/Readme.md
+++ b/src/molecules/formfields/CreditCardField/Readme.md
@@ -2,6 +2,7 @@ CreditCardField Example:
 
 ```example
     <CreditCardField
+      meta={{}}
       creditCardNumber={
         <TextField
           placeholder='Credit Card Number'

--- a/src/molecules/formfields/CreditCardField/__tests__/credit_card_field.spec.js
+++ b/src/molecules/formfields/CreditCardField/__tests__/credit_card_field.spec.js
@@ -7,7 +7,7 @@ import CreditCardField from 'molecules/formfields/CreditCardField';
 describe('<CreditCardField />', () => {
 
   it('renders', () => {
-    const wrapper = mount(<CreditCardField input={{}} />);
+    const wrapper = mount(<CreditCardField input={{}} meta={{}} />);
 
     expect(wrapper.type()).to.equal(CreditCardField);
   });

--- a/src/molecules/formfields/CreditCardField/index.js
+++ b/src/molecules/formfields/CreditCardField/index.js
@@ -19,20 +19,24 @@ function CreditCardField(props) {
     securityCode,
   } = props;
 
+  const showErrorMessage = (meta.visited && !meta.active) || meta.submitFailed;
+
   const classes = classnames(
     styles['credit-card'],
     meta && meta.active && styles['focused'],
-    meta && meta.touched && meta.error && !meta.active && styles['hasError'],
+    meta && showErrorMessage && meta.error && !meta.active && styles['hasError'],
     className,
   );
 
-  const message = meta && meta.touched && (meta.error || meta.warning);
+  const message = meta && showErrorMessage && (meta.error || meta.warning);
 
   return (
     <div>
       <div
         className={classes}
-        onBlur={input.onBlur}
+        onBlur={(e) => {
+          if (!e.relatedTarget) input.onBlur();
+        }}
         onFocus={input.onFocus}
       >
         <div className={styles['header']}>


### PR DESCRIPTION
@jmcolella @bradwheel this is my proposed solution for [this ticket](https://app.clubhouse.io/policygenius/story/4941/user-shouldn-t-see-invalid-state-on-cc-payment-info-until-they-ve-clicked-out-of-last-form-field).

Basically this just makes sure that the `onBlur` event only gets fired when the target is outside of the input in order to mimic how the event should get fired, and allows us to use the `meta.active` property correctly to display or hide validations