### PR TITLE
Policy Card tweaks

### DIFF
--- a/src/organisms/cards/PolicyCard/index.js
+++ b/src/organisms/cards/PolicyCard/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 import styles from './policy_card.module.scss';
 import propTypes from './propTypes';
 
@@ -22,11 +23,12 @@ function PolicyCard(props) {
     onDetails,
     compareSelected,
     onCompare,
-    footer
+    footer,
+    className
   } = props;
 
   return (
-    <div className={styles['policy-card']}>
+    <div className={classnames(styles['policy-card'], className)}>
       <div className={styles['body']}>
         <Compare
           onCompare={onCompare}

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -60,6 +60,7 @@ $footer: #f6f6f6;
 .carrier-logo {
   img {
     width: 105px;
+    max-width: 105px;
   }
 }
 


### PR DESCRIPTION
@cisacke made some tweaks

- Adds `className` prop to `PolicyCard` to align with general RCL practice
- Adds `max-width` on carrier image to override global image styling from `styles` which was causing the image to have 0 width on desktop