### PR TITLE
Tweak filter styles and update PolicyCard premium API

### DIFF
--- a/src/molecules/Filter/filter.module.scss
+++ b/src/molecules/Filter/filter.module.scss
@@ -1,17 +1,17 @@
 .filter {
   display: flex;
-  width: 100%;
 }
 
 .label {
   @include typography-6(false);
   color: color('neutral-3');
   padding-right: rem-calc(8px);
+  white-space: nowrap;
 }
 
 .select-wrapper {
-  position: relative;
   display: flex;
+  position: relative;
   width: 100%;
 
   &:after {
@@ -37,6 +37,8 @@
   -webkit-appearance: none;
   font-weight: 600;
   z-index: 1;
+  padding: 0;
+  padding-right: ru(1);
 
   &:focus {
     outline: none;

--- a/src/organisms/cards/PolicyCard/PolicyActions.js
+++ b/src/organisms/cards/PolicyCard/PolicyActions.js
@@ -18,21 +18,21 @@ const ResponsiveText = ({ text, offset, size }) =>
 
 export const PolicyActions = (props) => {
   const {
-    monthlyPremium,
+    premium,
     discount,
     onContinue,
     onDetails,
     onCompare
   } = props;
 
-  const formattedPremium = accounting.formatMoney(monthlyPremium);
+  const formattedPremium = accounting.formatMoney(premium.price);
 
   return (
     <div className={styles['actions']}>
       <Text type={5} color='neutral-2' semibold>
         <Text type={3} semibold>{formattedPremium}</Text>
         { ' ' }
-        mo
+        {premium.format}
       </Text>
       {discount && discount}
       <Spacer spacer={3} />
@@ -71,7 +71,10 @@ export const PolicyActions = (props) => {
 };
 
 PolicyActions.propTypes = {
-  monthlyPremium: PropTypes.number,
+  premium: PropTypes.shape({
+    price: PropTypes.number,
+    format: PropTypes.string,
+  }),
   discount: PropTypes.node,
   onContinue: PropTypes.func,
   onDetails: PropTypes.func,

--- a/src/organisms/cards/PolicyCard/__tests__/policy_card.spec.js
+++ b/src/organisms/cards/PolicyCard/__tests__/policy_card.spec.js
@@ -16,7 +16,10 @@ describe('<PolicyCard />', () => {
       financialStrength: 'A+',
       customerService: 'A+',
       totalCustomers: 5200000,
-      monthlyPremium: 19.8,
+      premium: {
+        price: 19.8,
+        format: 'mo'
+      },
       onContinue: () => {},
       onDetails: () => {},
       onCompare: () => {},

--- a/src/organisms/cards/PolicyCard/index.js
+++ b/src/organisms/cards/PolicyCard/index.js
@@ -17,7 +17,7 @@ function PolicyCard(props) {
     policyType,
     policyTooltip,
     carrierLogo,
-    monthlyPremium,
+    premium,
     discount,
     onContinue,
     onDetails,
@@ -51,7 +51,7 @@ function PolicyCard(props) {
           onDetails={onDetails}
           onCompare={onCompare}
           discount={discount}
-          monthlyPremium={monthlyPremium}
+          premium={premium}
         />
       </div>
       {!!footer.length &&

--- a/src/organisms/cards/PolicyCard/propTypes.js
+++ b/src/organisms/cards/PolicyCard/propTypes.js
@@ -31,9 +31,12 @@ export default {
    */
   totalCustomers: PropTypes.number.isRequired,
   /**
-   * The insurance carrier logo
+   * The insurance premium
    */
-  monthlyPremium: PropTypes.number.isRequired,
+  premium: PropTypes.shape({
+    price: PropTypes.number.isRequired,
+    format: PropTypes.string.isRequired,
+  }),
   /**
    * Optional discount percentage
    */


### PR DESCRIPTION
@cisacke CR please. Needed for completion of [this ticket](https://app.clubhouse.io/policygenius/story/6830/shoppers-can-change-coverage-term-view-payments-yearly-monthly-and-sort-policies)

- Tweaks styling for Filter to (finally) work best in implementation
- Updates `monthlyPremium` prop for `PolicyCard` to work with both monthly/annual premiums