### PR TITLE
Expand checkbox click; add unique identifier for checkbox field

### DIFF
--- a/src/organisms/cards/PolicyCard/Compare.js
+++ b/src/organisms/cards/PolicyCard/Compare.js
@@ -6,22 +6,28 @@ import Spacer from 'atoms/Spacer';
 import CheckBoxField from 'molecules/formfields/CheckBoxField';
 import styles from './policy_card.module.scss';
 
-const Compare = ({ compareSelected, onCompare }) =>
+const Compare = ({ compareSelected, onCompare, name }) =>
   <Hide hideOn='small' className={styles['compare']}>
-    <Text
-      color='neutral-3'
-      light
-      className={compareSelected && styles['checked']}
+    <div
+      id={`${name}-checkbox-wrapper`}
+      className={styles['checkbox-wrapper']}
+      onClick={onCompare}
     >
-      Compare
-    </Text>
-    <Spacer spacer={1} />
-    <CheckBoxField
-      input={{
-        onChange: onCompare,
-        value: compareSelected
-      }}
-    />
+      <Text
+        color='neutral-3'
+        light
+        className={compareSelected && styles['checked']}
+      >
+        Compare
+      </Text>
+      <Spacer spacer={1} />
+      <CheckBoxField
+        input={{
+          value: compareSelected,
+          name
+        }}
+      />
+    </div>
     <div className={styles['divider']} />
   </Hide>
 
@@ -29,7 +35,8 @@ const Compare = ({ compareSelected, onCompare }) =>
 
 Compare.propTypes = {
   compareSelected: PropTypes.bool,
-  onCompare: PropTypes.func
+  onCompare: PropTypes.func,
+  name: PropTypes.string,
 };
 
 export default Compare;

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -10,30 +10,36 @@ exports[`<PolicyCard /> renders correctly 1`] = `
     <div
       className="hide compare small"
     >
-      <p
-        className="text typography-6 light neutral-3 undefined p undefined"
-      >
-        Compare
-      </p>
       <div
-        className="top-1"
-      />
-      <label
-        className="checkbox"
-        htmlFor="checkbox-undefined"
+        className="checkbox-wrapper"
+        id="undefined-checkbox-wrapper"
+        onClick={[Function]}
       >
-        <input
-          checked={undefined}
-          className="checkbox-input"
-          id="checkbox-undefined"
-          onChange={[Function]}
-          type="checkbox"
-          value={undefined}
+        <p
+          className="text typography-6 light neutral-3 undefined p undefined"
+        >
+          Compare
+        </p>
+        <div
+          className="top-1"
         />
-        <span
-          className="checkbox-label light"
-        />
-      </label>
+        <label
+          className="checkbox"
+          htmlFor="checkbox-undefined"
+        >
+          <input
+            checked={undefined}
+            className="checkbox-input"
+            id="checkbox-undefined"
+            name={undefined}
+            type="checkbox"
+            value={undefined}
+          />
+          <span
+            className="checkbox-label light"
+          />
+        </label>
+      </div>
       <div
         className="divider"
       />

--- a/src/organisms/cards/PolicyCard/__tests__/policy_card.spec.js
+++ b/src/organisms/cards/PolicyCard/__tests__/policy_card.spec.js
@@ -22,7 +22,9 @@ describe('<PolicyCard />', () => {
       },
       onContinue: () => {},
       onDetails: () => {},
-      onCompare: () => {},
+      compareCheckbox: {
+        onCompare: () => {},
+      }
     };
   });
 

--- a/src/organisms/cards/PolicyCard/index.js
+++ b/src/organisms/cards/PolicyCard/index.js
@@ -21,18 +21,16 @@ function PolicyCard(props) {
     discount,
     onContinue,
     onDetails,
-    compareSelected,
-    onCompare,
+    compareCheckbox,
     footer,
-    className
+    className,
   } = props;
 
   return (
     <div className={classnames(styles['policy-card'], className)}>
       <div className={styles['body']}>
         <Compare
-          onCompare={onCompare}
-          compareSelected={compareSelected}
+          {...compareCheckbox}
         />
         <CarrierLogo
           carrierLogo={carrierLogo}
@@ -49,7 +47,7 @@ function PolicyCard(props) {
         <PolicyActions
           onContinue={onContinue}
           onDetails={onDetails}
-          onCompare={onCompare}
+          onCompare={compareCheckbox.onCompare}
           discount={discount}
           premium={premium}
         />

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -52,6 +52,13 @@ $footer: #f6f6f6;
   display: block;
 }
 
+.checkbox-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+}
+
 .checked {
   color: color('neutral-2');
   font-weight: 600;

--- a/src/organisms/cards/PolicyCard/propTypes.js
+++ b/src/organisms/cards/PolicyCard/propTypes.js
@@ -54,11 +54,13 @@ export default {
    */
   onDetails: PropTypes.func.isRequired,
   /**
-   * Click handler for the compare checkbox/ button
+   * Props for the Checkbox to compare
+   *
+   * NOTE: `name` must be unique
    */
-  onCompare: PropTypes.func.isRequired,
-  /**
-   * Whether or not the compare checkbox is selected
-   */
-  compareSelected: PropTypes.bool,
+  compareCheckbox: PropTypes.shape({
+    onCompare: PropTypes.func.isRequired,
+    compareSelected: PropTypes.bool,
+    name: PropTypes.string,
+  })
 };


### PR DESCRIPTION
@cisacke CR please

- Adds unique identifier to `CheckboxField` to prevent issues where the wrong box is selected in a list of boxes
- Expands checkbox click to include 'Compare' text and immediate surrounding area