### PR TITLE
Add new button variant, add help cursor to PolicyType

### DIFF
--- a/src/atoms/Button/Readme.md
+++ b/src/atoms/Button/Readme.md
@@ -78,3 +78,9 @@ Toggle Button Active Example:
 ```example
       <Button variant='toggle-active'>Toggle Button</Button>
 ```
+
+Slim Button Example:
+
+``` example
+      <Button variant='action' slim>A Vertically Slim Button</Button>
+```

--- a/src/atoms/Button/buttons.module.scss
+++ b/src/atoms/Button/buttons.module.scss
@@ -107,6 +107,12 @@ $button-solid-background-tertiary-color:   #f08f5c;
   color: $button-info-color;
 }
 
+.slim {
+  padding-top: ru(.5);
+  padding-bottom: ru(.5);
+  line-height: 1rem;
+}
+
 .toggle {
   @include typography-7(false);
   @include typography-regular;
@@ -118,7 +124,7 @@ $button-solid-background-tertiary-color:   #f08f5c;
 
   padding-top: ru(.5);
   padding-bottom: ru(.5);
-  line-height: 1em;
+  line-height: 1rem;
 
   &:focus {
     outline: none;

--- a/src/atoms/Button/index.js
+++ b/src/atoms/Button/index.js
@@ -14,6 +14,7 @@ function Button( props ) {
     icon,
     disabled,
     shake,
+    slim,
     ...rest,
   } = props;
 
@@ -22,6 +23,7 @@ function Button( props ) {
     shake && styles['shaking'],
     styles[variant],
     className,
+    slim && styles['slim'],
   ];
 
   return (
@@ -64,6 +66,10 @@ Button.propTypes = {
    * Triggers shake animation if true
    */
   shake: PropTypes.bool,
+  /**
+   * Reduces vertical padding if true
+   */
+  slim: PropTypes.bool,
   onClick: PropTypes.func,
 };
 

--- a/src/organisms/cards/PolicyCard/PolicyActions.js
+++ b/src/organisms/cards/PolicyCard/PolicyActions.js
@@ -39,6 +39,7 @@ export const PolicyActions = (props) => {
       <Layout largeCols={[ 6 ]} mediumCols={[ 12 ]} smallCols={[ 12, 6, 6 ]}>
         <Button
           variant='action'
+          slim
           onClick={onContinue}
           className={classnames(styles['continue'])}
         >
@@ -50,7 +51,7 @@ export const PolicyActions = (props) => {
             Continue
           </Hide>
         </Button>
-        <Button onClick={onDetails}>
+        <Button slim onClick={onDetails}>
           <Hide hideOn='small medium xLarge xxLarge'>
             <ResponsiveText text='Details' offset={-10} size={75} />
           </Hide>
@@ -61,6 +62,7 @@ export const PolicyActions = (props) => {
         <Hide hideOn='medium large xLarge xxLarge'>
           <Button
             onClick={onCompare}
+            slim
           >
             Compare
           </Button>

--- a/src/organisms/cards/PolicyCard/PolicyType.js
+++ b/src/organisms/cards/PolicyCard/PolicyType.js
@@ -39,7 +39,8 @@ export const PolicyType = ({ policyType, policyTooltip, policyTypeHoverMessage }
           </Text>
         </div>
       }
-      hoverMessageClassName={styles['policy-type-tooltip']}
+      hoverMessageClassName={styles['policy-type-hover-message']}
+      className={styles['policy-type-tooltip']}
     >
       { policyTypeHoverMessage }
     </Tooltip>

--- a/src/organisms/cards/PolicyCard/Readme.md
+++ b/src/organisms/cards/PolicyCard/Readme.md
@@ -29,7 +29,7 @@
         />
       }
       premium={{
-        price: '19.80',
+        price: 19.80,
         format: 'mo'
       }}
       discount={

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -56,7 +56,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
       className="policy-type"
     >
       <span
-        className="tooltip-wrapper"
+        className="tooltip-wrapper policy-type-tooltip"
         onClick={[Function]}
       >
         <div>
@@ -81,7 +81,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
           </strong>
         </div>
         <span
-          className="hover-message policy-type-tooltip"
+          className="hover-message policy-type-hover-message"
         >
           <div />
         </span>
@@ -167,7 +167,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
           style={undefined}
         >
           <button
-            className="button action continue"
+            className="button action continue slim"
             disabled={undefined}
             onClick={[Function]}
             type="button"
@@ -201,7 +201,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
           style={undefined}
         >
           <button
-            className="button button"
+            className="button button slim"
             disabled={undefined}
             onClick={[Function]}
             type="button"
@@ -238,7 +238,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
             className="hide medium large xLarge xxLarge"
           >
             <button
-              className="button button"
+              className="button button slim"
               disabled={undefined}
               onClick={[Function]}
               type="button"

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -79,10 +79,14 @@ $footer: #f6f6f6;
   }
 }
 
-.policy-type-tooltip {
+.policy-type-hover-message {
   left: 50%;
   top: calc(100% + 18px);
   width: ru(11.5);
+}
+
+.policy-type-tooltip {
+  cursor: help;
 }
 
 @media #{$small-only} {
@@ -175,5 +179,6 @@ $footer: #f6f6f6;
   .policy-name {
     margin: rem-calc(3px) 0;
     line-height: ru(1);
+    display: block;
   }
 }


### PR DESCRIPTION
@jmcolella 👀  please - what do you think about allowing multiple variants for Button? Maybe better to add a prop, `slim` which is boolean? Also just added some tweaks for [this ticket](https://app.clubhouse.io/policygenius/story/7380/shopper-should-be-able-to-click-details-button-on-comparison-page)