### PR TITLE
Fix PolicyCard IE11

### DIFF
--- a/src/atoms/Layout/layout.module.scss
+++ b/src/atoms/Layout/layout.module.scss
@@ -7,6 +7,7 @@ $spacer-base: .25;
 
   width: $width;
   flex-basis: $width;
+  max-width: $width;
   flex-grow: 0;
   flex-shrink: 1;
 }

--- a/src/organisms/cards/PolicyCard/CarrierLogo.js
+++ b/src/organisms/cards/PolicyCard/CarrierLogo.js
@@ -5,7 +5,6 @@ import styles from './policy_card.module.scss';
 export const CarrierLogo = ({ carrierLogo }) =>
   <div className={styles['carrier-logo']}>
     {carrierLogo}
-    <div className={styles['divider']} />
   </div>
 ;
 

--- a/src/organisms/cards/PolicyCard/Compare.js
+++ b/src/organisms/cards/PolicyCard/Compare.js
@@ -29,7 +29,6 @@ const Compare = ({ compareSelected, onCompare, name }) =>
         }}
       />
     </div>
-    <div className={styles['divider']} />
   </Hide>
 
 ;

--- a/src/organisms/cards/PolicyCard/PolicyActions.js
+++ b/src/organisms/cards/PolicyCard/PolicyActions.js
@@ -10,7 +10,11 @@ import Spacer from 'atoms/Spacer';
 import styles from './policy_card.module.scss';
 
 const ResponsiveText = ({ text, offset, size }) =>
-  <svg width='100%' height='100%' viewBox={`${offset} 0 ${size} 15`}>
+  <svg
+    width='100%'
+    viewBox={`${offset} 0 ${size} 15`}
+    className={styles['svg-text']}
+  >
     <text x='0' y='12'>{text}</text>
   </svg>
 
@@ -42,7 +46,7 @@ export const PolicyActions = (props) => {
         <Text type={7} color='neutral-2'>{premium.defaultText}</Text>
       }
       <Spacer spacer={3} />
-      <Layout largeCols={[ 6 ]} mediumCols={[ 12 ]} smallCols={[ 12, 6, 6 ]}>
+      <Layout largeCols={[ 6 ]} mediumCols={[ 12 ]} smallCols={[ 12, 6, 6 ]} style={{ width: '100%' }}>
         <Button
           variant='action'
           slim

--- a/src/organisms/cards/PolicyCard/PolicyInformation.js
+++ b/src/organisms/cards/PolicyCard/PolicyInformation.js
@@ -44,7 +44,6 @@ export const PolicyInformation = ({ financialStrength, customerService, totalCus
     >
       { totalCustomers.hoverMessage }
     </Tooltip>
-    <div className={styles['divider']} />
   </Hide>
 ;
 

--- a/src/organisms/cards/PolicyCard/PolicyType.js
+++ b/src/organisms/cards/PolicyCard/PolicyType.js
@@ -44,7 +44,6 @@ export const PolicyType = ({ policyType, policyTooltip, policyTypeHoverMessage }
     >
       { policyTypeHoverMessage }
     </Tooltip>
-    <div className={styles['divider']} />
   </div>
 ;
 

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -40,18 +40,18 @@ exports[`<PolicyCard /> renders correctly 1`] = `
           />
         </label>
       </div>
-      <div
-        className="divider"
-      />
     </div>
+    <div
+      className="divider"
+    />
     <div
       className="carrier-logo"
     >
       <div />
-      <div
-        className="divider"
-      />
     </div>
+    <div
+      className="divider"
+    />
     <div
       className="policy-type"
     >
@@ -87,10 +87,10 @@ exports[`<PolicyCard /> renders correctly 1`] = `
         </span>
         <noscript />
       </span>
-      <div
-        className="divider"
-      />
     </div>
+    <div
+      className="divider"
+    />
     <div
       className="hide policy-info small medium"
     >
@@ -169,10 +169,10 @@ exports[`<PolicyCard /> renders correctly 1`] = `
         </span>
         <noscript />
       </span>
-      <div
-        className="divider"
-      />
     </div>
+    <div
+      className="divider info-divider"
+    />
     <div
       className="actions"
     >
@@ -194,7 +194,11 @@ exports[`<PolicyCard /> renders correctly 1`] = `
       />
       <div
         className="layout"
-        style={undefined}
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
       >
         <div
           className="col col-sm-12 col-md-12 col-lg-6 bottom-spacing-undefined"
@@ -211,7 +215,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
               className="hide small medium xLarge xxLarge"
             >
               <svg
-                height="100%"
+                className="svg-text"
                 viewBox="-3 0 75 15"
                 width="100%"
               >
@@ -245,7 +249,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
               className="hide small medium xLarge xxLarge"
             >
               <svg
-                height="100%"
+                className="svg-text"
                 viewBox="-10 0 75 15"
                 width="100%"
               >

--- a/src/organisms/cards/PolicyCard/index.js
+++ b/src/organisms/cards/PolicyCard/index.js
@@ -33,19 +33,23 @@ function PolicyCard(props) {
         <Compare
           {...compareCheckbox}
         />
+        <div className={styles['divider']} />
         <CarrierLogo
           carrierLogo={carrierLogo}
         />
+        <div className={styles['divider']} />
         <PolicyType
           policyType={policyType}
           policyTooltip={policyTooltip}
           policyTypeHoverMessage={policyTypeHoverMessage}
         />
+        <div className={styles['divider']} />
         <PolicyInformation
           financialStrength={financialStrength}
           customerService={customerService}
           totalCustomers={totalCustomers}
         />
+        <div className={classnames(styles['divider'], styles['info-divider'])} />
         <PolicyActions
           onContinue={onContinue}
           onDetails={onDetails}

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -89,6 +89,11 @@ $footer: #f6f6f6;
   cursor: help;
 }
 
+/* IE 11 hack to make sure svg does not take up 100% height */
+.svg-text {
+  max-height: rem-calc(37px);
+}
+
 @media #{$small-only} {
   .policy-tooltip {
     > * {

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -24,6 +24,7 @@ $footer: #f6f6f6;
 .body {
   padding: rem-calc(20px) 0 ru(1);
   display: flex;
+  align-items: center;
 }
 
 .footer {
@@ -38,8 +39,10 @@ $footer: #f6f6f6;
 .divider {
   height: ru(3.25);
   border-left: 1px solid $border;
-  position: absolute;
-  right: 0;
+}
+
+.info-divider {
+  display: none;
 }
 
 .node {
@@ -91,7 +94,7 @@ $footer: #f6f6f6;
 
 /* IE 11 hack to make sure svg does not take up 100% height */
 .svg-text {
-  max-height: rem-calc(37px);
+  max-height: ru(1);
 }
 
 @media #{$small-only} {
@@ -114,10 +117,11 @@ $footer: #f6f6f6;
     display: none;
   }
 
-  .actions, {
+  .actions {
     padding: ru(1) ru(1) 0 ru(1);
     text-align: center;
     border-top: 1px solid $border;
+    width: 100%;
   }
 
   .policy-type {
@@ -189,6 +193,12 @@ $footer: #f6f6f6;
   .policy-name {
     margin: rem-calc(3px) 0;
     line-height: ru(1);
+    display: block;
+  }
+}
+
+@media #{$large-up} {
+  .info-divider {
     display: block;
   }
 }

--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -1,8 +1,8 @@
 $border: #dfdfdf;
 $footer: #f6f6f6;
 
-@mixin section($grow, $centered) {
-  flex: #{$grow} 1 0;
+@mixin section($grow, $basis, $centered) {
+  flex: #{$grow} 1 #{$basis};
   padding: 0 ru(1.25);
   display: flex;
   flex-direction: column;
@@ -146,21 +146,21 @@ $footer: #f6f6f6;
 
 @media #{$medium-up} {
   .compare {
-    @include section(0, true);
+    @include section(0, 10%, true);
     label { margin-left: rem-calc(8px); }
     min-width: ru(5.25);
   }
 
   .carrier-logo {
-    @include section(0, true);
+    @include section(0, 15%, true);
   }
 
   .policy-type {
-    @include section(1, false);
+    @include section(1, 25%, false);
   }
 
   .policy-info {
-    @include section(1, false);
+    @include section(1, 25%, false);
   }
 
   .policy-info > strong {
@@ -177,7 +177,7 @@ $footer: #f6f6f6;
   }
 
   .actions {
-    @include section(1, true);
+    @include section(1, 25%, true);
     text-align: center;
   }
 


### PR DESCRIPTION
@cisacke CR please

[CH](https://app.clubhouse.io/policygenius/story/7381/shoppers-should-see-correct-policycards-in-ie11-and-firefox)

- Fixes `PolicyCard` layout for IE 11 (and Firefox/Safari)
- Gives `max-width` to all `Layout` children

@drewdrewthis please weigh in on the second bullet point. IE has a bug where flex children do not respect `box-sizing` if there isn't a `max-width` set, essentially making all children of `Layout` broken (particularly those children that don't take up 12 columns). To rectify this, I added `max-width` to all children, equal to its `width` and `flex-basis`. Since we are setting `flex-grow: 0`, this change didn't seem to change much, but wanted to get your opinion. You can read more about the bug [here](https://github.com/philipwalton/flexbugs/issues/3)