### PR TITLE
Fix checkbox click issue and make target bigger

### DIFF
--- a/src/organisms/cards/PolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/PolicyCard/policy_card.module.scss
@@ -58,9 +58,21 @@ $footer: #f6f6f6;
 
 .checkbox-wrapper {
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: center;
-  cursor: pointer;
+  padding: rem-calc(8px) 0;
+
+  &:after {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background: transparent;
+    content: '';
+    cursor: pointer;
+  }
 }
 
 .checked {


### PR DESCRIPTION
@cisacke CR please

- Adds a transparent mask over the `Compare` checkbox that handles the `onCompare` function with no interference from anything inside of it
- Makes target for `onCompare` a bit bigger