### PR TITLE
Fix selects in firefox

### DIFF
--- a/src/molecules/formfields/SelectField/select_field.module.scss
+++ b/src/molecules/formfields/SelectField/select_field.module.scss
@@ -39,12 +39,6 @@
   .select-wrapper {
     select {
       -moz-appearance: none;
-      color: rgba(0,0,0,0);
-    }
-
-    select:-moz-focusring {
-      color: transparent;
-      text-shadow: 0 0 0 color('brand-2');
     }
   }
 }

--- a/src/utils/fieldUtils/__tests__/renderOptGroup.spec.js
+++ b/src/utils/fieldUtils/__tests__/renderOptGroup.spec.js
@@ -15,20 +15,16 @@ describe('renderOptGroup Util', () => {
       ],
     };
 
-    const wrapper = shallow(renderOptGroup(optGroup));
+    const wrapper = shallow(renderOptGroup(optGroup, 0));
 
     expect(wrapper.is('optgroup')).to.be.true;
     expect(wrapper.key().includes(optGroup.reactKey)).to.be.true;
     expect(wrapper.find('option').length).to.equal(2);
   });
 
-  it('generates a random key if one has not been provided', () => {
-    const wrapper = shallow(renderOptGroup({}));
+  it('uses the index as a key if one has not been provided', () => {
+    const wrapper = shallow(renderOptGroup({}, 0));
 
-    expect(wrapper.key()).to.be.a('string');
-    expect(wrapper.key().includes('grp-')).to.be.true;
-    expect(wrapper.key().length).to.be.above(5);
+    expect(wrapper.key()).to.eq('0');
   });
-
-
 });

--- a/src/utils/fieldUtils/__tests__/renderOption.spec.js
+++ b/src/utils/fieldUtils/__tests__/renderOption.spec.js
@@ -12,7 +12,7 @@ describe('renderOption Util', () => {
       label: 'Test Label',
     };
 
-    const wrapper = shallow(renderOption(sampleOption));
+    const wrapper = shallow(renderOption(sampleOption, 0));
 
     expect(wrapper.is('option')).to.be.true;
     expect(wrapper.props().value).to.equal(sampleOption.value);
@@ -20,12 +20,9 @@ describe('renderOption Util', () => {
     expect(wrapper.contains('Test Label')).to.be.true;
   });
 
-  it('generates a random key if one has not been provided', () => {
-    const wrapper = shallow(renderOption({}));
+  it('uses the index as a key if one has not been provided', () => {
+    const wrapper = shallow(renderOption({}, 0));
 
-    expect(wrapper.key()).to.be.a('string');
-    expect(wrapper.key().includes('opt-')).to.be.true;
-    expect(wrapper.key().length).to.be.above(5);
+    expect(wrapper.key()).to.eq('0');
   });
-
 });

--- a/src/utils/fieldUtils/renderOptGroup.js
+++ b/src/utils/fieldUtils/renderOptGroup.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import renderOption from 'utils/fieldUtils/renderOption';
 
-const randomStr = () => Math.random().toString(36).substring(7);
-
 function renderOptions(options) {
   if (!options) return null;
 
   return options.map(renderOption);
 }
 
-export default function renderOptGroup(optionGroup, idx = 0) {
+export default function renderOptGroup(optionGroup, idx) {
   const {
     reactKey,
     group,
@@ -18,7 +16,7 @@ export default function renderOptGroup(optionGroup, idx = 0) {
 
   return (
     <optgroup
-      key={reactKey ? `${reactKey}-${idx}` : `grp-${randomStr()}`}
+      key={reactKey ? `${reactKey}-${idx}` : idx.toString()}
       label={group}
     >
       { renderOptions(options) }

--- a/src/utils/fieldUtils/renderOption.js
+++ b/src/utils/fieldUtils/renderOption.js
@@ -3,9 +3,7 @@ import renderOptGroup from 'utils/fieldUtils/renderOptGroup';
 
 import styles from 'molecules/formfields/shared/formfields.module.scss';
 
-const randomStr = () => Math.random().toString(36).substring(7);
-
-export default function renderOption(opt, idx = 0) {
+export default function renderOption(opt, idx) {
   if (opt.group) return renderOptGroup(opt, idx);
 
   const {
@@ -16,7 +14,7 @@ export default function renderOption(opt, idx = 0) {
 
   return (
     <option
-      key={reactKey ? `${reactKey}-${idx}` : `opt-${randomStr()}`}
+      key={reactKey ? `${reactKey}-${idx}` : idx.toString()}
       value={value}
       className={styles['option']}
     >


### PR DESCRIPTION
We were passing a new random string to the key prop every time a select
option was rendered. For some reason Chrome knew how to deal with that,
but Firefox couldn't. This caused inputs to lose their selected value
when re-rendered.