### PR TITLE
Update breakpoints for rebrand

### DIFF
--- a/src/assets/stylesheets/utilities/_break_points.scss
+++ b/src/assets/stylesheets/utilities/_break_points.scss
@@ -2,9 +2,10 @@
 
 $page-max-width: 80.5rem;
 
-$small-range: (0, 48em);
-$medium-range: (48.0625em, 64em);
-$large-range: (64.0625em, 80em);
+$mobile-range: (0, 47.9375em);
+$tablet-range: (48em, 64em);
+$desktop-range: (64.0625em, 80em);
+
 $xlarge-range: (80.0625em, 90em);
 $xxlarge-range: (90.0625em);
 
@@ -13,15 +14,24 @@ $screen: 'only screen';
 $landscape: '#{$screen} and (orientation: landscape)';
 $portrait: '#{$screen} and (orientation: portrait)';
 
-$small-up: $screen;
-$small-only: '#{$screen} and (max-width: #{upper-bound($small-range)})';
+$mobile: $screen;
+$mobile-only: '#{$screen} and (max-width: #{upper-bound($mobile-range)})';
+$tablet: '#{$screen} and (min-width:#{lower-bound($tablet-range)})';
+$tablet-only: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($tablet-range)})';
+$desktop: '#{$screen} and (min-width:#{lower-bound($desktop-range)})';
 
-$medium-bottom: '#{$screen} and (max-width:#{upper-bound($medium-range)})';
-$medium-up: '#{$screen} and (min-width:#{lower-bound($medium-range)})';
-$medium-only: '#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($medium-range)})';
 
-$large-up: '#{$screen} and (min-width:#{lower-bound($large-range)})';
-$large-only: '#{$screen} and (min-width:#{lower-bound($large-range)}) and (max-width:#{upper-bound($large-range)})';
+// previous breakpoint names left for backwards compatability
+
+$small-up: $mobile;
+$small-only: $mobile-only;
+
+$medium-bottom: '#{$screen} and (max-width:#{upper-bound($tablet-range)})';
+$medium-up: $tablet;
+$medium-only: $tablet-only;
+
+$large-up: $desktop;
+$large-only: '#{$screen} and (min-width:#{lower-bound($desktop-range)}) and (max-width:#{upper-bound($desktop-range)})';
 
 $xlarge-up: '#{$screen} and (min-width:#{lower-bound($xlarge-range)})';
 $xlarge-only: '#{$screen} and (min-width:#{lower-bound($xlarge-range)}) and (max-width:#{upper-bound($xlarge-range)})';
@@ -29,6 +39,6 @@ $xlarge-only: '#{$screen} and (min-width:#{lower-bound($xlarge-range)}) and (max
 $xxlarge-up: '#{$screen} and (min-width:#{lower-bound($xxlarge-range)})';
 $xxlarge-only: '#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (max-width:#{upper-bound($xxlarge-range)})';
 
-$small-and-medium-only: '#{$screen} and (max-width: #{upper-bound($medium-range)})';
-$medium-up-to-large: '#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($large-range)})';
-$medium-up-to-xxlarge: '#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($xlarge-range)})';
+$small-and-medium-only: '#{$screen} and (max-width: #{upper-bound($tablet-range)})';
+$medium-up-to-large: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($desktop-range)})';
+$medium-up-to-xxlarge: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($xlarge-range)})';

--- a/src/atoms/StyledWrapper/constants/breakpoints.js
+++ b/src/atoms/StyledWrapper/constants/breakpoints.js
@@ -1,14 +1,14 @@
-const smallRange = {
+const mobileRange = {
   lower: '0em',
-  upper: '48em',
+  upper: '47.9375em',
 };
 
-const mediumRange = {
-  lower: '48.0625em',
+const tabletRange = {
+  lower: '48em',
   upper: '64em',
 };
 
-const largeRange = {
+const desktopRange = {
   lower: '64.0625em',
   upper: '80em',
 };
@@ -25,13 +25,27 @@ const xxLargeRange = {
 
 const screen = 'only screen';
 
+const mobile = screen;
+const mobileOnly = `${screen} and (max-width: ${mobileRange.upper})`;
+const tablet = `${screen} and (min-width: ${tabletRange.lower})`;
+const tabletOnly = `${screen} and (min-width: ${tabletRange.lower}) and (max-width: ${tabletRange.upper})`;
+const desktop = `${screen} and (min-width: ${desktopRange.lower})`;
+
 export default {
-  smallUp: screen,
-  smallOnly: `${screen} and (max-width: ${smallRange.upper})`,
-  mediumUp: `${screen} and (min-width: ${mediumRange.lower})`,
-  mediumOnly: `${screen} and (min-width: ${mediumRange.lower}) and (max-width: ${mediumRange.upper})`,
-  largeUp: `${screen} and (min-width: ${largeRange.lower})`,
-  largeOnly: `${screen} and (min-width: ${largeRange.lower}) and (max-width: ${largeRange.upper})`,
+  mobile,
+  mobileOnly,
+  tablet,
+  tabletOnly,
+  desktop,
+
+  // previous breakpoint names left for backwards compatability
+
+  smallUp: mobile,
+  smallOnly: mobileOnly,
+  mediumUp: tablet,
+  mediumOnly: tabletOnly,
+  largeUp: desktop,
+  largeOnly: `${screen} and (min-width: ${desktopRange.lower}) and (max-width: ${desktopRange.upper})`,
   xLargeUp: `${screen} and (min-width: ${xLargeRange.lower})`,
   xLargeOnly: `${screen} and (min-width: ${xLargeRange.lower}) and (max-width: ${xLargeRange.upper})`,
   xxLargeUp: `${screen} and (min-width: ${xxLargeRange.lower})`,

--- a/src/wrappers/Hide/Readme.md
+++ b/src/wrappers/Hide/Readme.md
@@ -3,7 +3,7 @@
 ```jsx
     <div>
       <Text>hello, </Text>
-      <Hide hideOn='small medium'>
+      <Hide hideOn='mobile tablet'>
         <Spacer small />
       </Hide>
       <Text>world</Text>

--- a/src/wrappers/Hide/hide.module.scss
+++ b/src/wrappers/Hide/hide.module.scss
@@ -1,10 +1,19 @@
 $screens: (
+  $mobile-only: mobile,
+  $tablet: tablet-up,
+  $tablet-only: tablet,
+  $desktop: desktop,
+);
+
+// previous breakpoints left for backwards compatability
+$oldScreens: (
   $small-only: small,
   $medium-only: medium,
   $large-only: large,
   $xlarge-only: xLarge,
   $xxlarge-up: xxLarge
 );
+
 
 @each $screenSize, $className in $screens {
   @media #{$screenSize} {
@@ -14,3 +23,10 @@ $screens: (
   }
 }
 
+@each $screenSize, $className in $oldScreens {
+  @media #{$screenSize} {
+    .#{$className} {
+      display: none;
+    }
+  }
+}

--- a/src/wrappers/Hide/index.js
+++ b/src/wrappers/Hide/index.js
@@ -37,9 +37,24 @@ Hide.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * The screen sizes on which to hide the children -- use screen sizes from `Layout` component
+   * The screen sizes on which to hide the children. Pass in a space separated string
+   *
+   * Values:
+   * * `mobile`: hides element on screens up to 767px
+   *
+   * * `tablet`: hide element only on screens from 768px to 1024px
+   *
+   * * `tablet-up`: hide element on screens from 768px up
+   *
+   * * `desktop`: hide element on screens from 1025px up
    */
-  hideOn: PropTypes.string.isRequired,
+  /* eslint-disable */
+  hideOn: (props, propName, componentName) => {
+    if (/small|medium|large|xLarge|xxLarge/.test(props[propName])) {
+      throw new Error(`Deprecated prop values for ${propName} supplied to ${componentName}. Please use one or a combination of mobile, tablet and desktop. Refer to RCL documentation for correct breakpoint mappings.`);
+    }
+  }
+  /* eslint-enable */
 };
 
 export default Hide;


### PR DESCRIPTION
@drewdrewthis @sunnymis 👀  please

- Updates breakpoint between tablet/mobile: Mobile upper range is 767, tablet low range is 768
- Adds new keywords for breakpoints: `mobile`, `tablet`, and `desktop` exposed to `StyledWrapper`