### PR TITLE
Tweak RadioCard prop validation

### DIFF
--- a/src/organisms/cards/RadioCard/index.js
+++ b/src/organisms/cards/RadioCard/index.js
@@ -140,7 +140,10 @@ RadioCard.propTypes = {
   sections: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
-      value: PropTypes.string,
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+      ]),
       sublabel: PropTypes.string
     })
   ),


### PR DESCRIPTION
- Allow either string or number for section `value`