### PR TITLE
Show grab/grabbing for entire slider

### DIFF
--- a/src/molecules/formfields/SliderField/slider_field.module.scss
+++ b/src/molecules/formfields/SliderField/slider_field.module.scss
@@ -18,6 +18,15 @@
     box-sizing: border-box;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   }
+  :global(.rc-slider):hover * {
+    cursor: pointer;
+    cursor: -webkit-grab;
+    cursor: grab;
+  }
+  :global(.rc-slider):active * {
+    cursor: -webkit-grabbing;
+    cursor: grabbing;
+  }
   :global(.rc-slider-rail) {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
Current rc-slider behavior shows a plain cursor when hovering over slider-rail, even when you're technically in an `active` state, dragging the handle. Doesn't really show when your slider contains many options, but is buggy when there are only a few (5-10) options. This maintains the grab/grabbing cursor throughout.

@jmcolella @cisacke @trevornelson 