### PR TITLE
Display active step only in progress bar

### DIFF
--- a/src/molecules/StepIndicator/ProgressBarStep.js
+++ b/src/molecules/StepIndicator/ProgressBarStep.js
@@ -71,14 +71,12 @@ export default class ProgressBarStep extends Component {
   }
 
   render() {
-    const {
-      step
-    } = this.props;
+    const { step } = this.props;
 
     return (
       <div className={styles['breadcrumb']} onClick={this.handleClick}>
         <div className={classnames(this.textClasses())}>
-          <Text tag='span' type={7} {...this.textProps()}>{ step.text }</Text>
+          <Text tag='span' type={7} className={styles['step-title']} {...this.textProps()}>{ step.text }</Text>
         </div>
         <div className={classnames(...this.circleWrapperClasses())}>
           <div className={classnames(...this.circleClasses())} />

--- a/src/molecules/StepIndicator/__tests__/__snapshots__/step_indicator.spec.js.snap
+++ b/src/molecules/StepIndicator/__tests__/__snapshots__/step_indicator.spec.js.snap
@@ -2,6 +2,10 @@
 
 exports[`<StepIndicator /> renders correctly 1`] = `
 <div
-  className="step-indicator"
-/>
+  className=""
+>
+  <div
+    className="step-indicator"
+  />
+</div>
 `;

--- a/src/molecules/StepIndicator/index.js
+++ b/src/molecules/StepIndicator/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 import classnames from 'classnames';
+import Text from 'atoms/Text';
 import ProgressBarStep from './ProgressBarStep';
 import styles from './step_indicator.module.scss';
 
@@ -11,20 +13,22 @@ function StepIndicator(props) {
     navigateToPath
   } = props;
 
-  const classes = [
-    styles['step-indicator'],
-    className,
-  ];
+  const activeStep = steps.find(step => step.currentStepActive) || steps[0];
 
   return (
-    <div className={classnames(...classes)}>
-      {steps.map((step, idx) =>
-        <ProgressBarStep
-          key={idx}
-          step={step}
-          navigateToPath={navigateToPath}
-        />
-      )}
+    <div className={classnames(className)}>
+      <Text tag='div' type={7} color='neutral-2' weight='semibold' className={styles['active-step']}>
+        {get(activeStep, 'text', '')}
+      </Text>
+      <div className={styles['step-indicator']}>
+        {steps.map((step, idx) =>
+          <ProgressBarStep
+            key={idx}
+            step={step}
+            navigateToPath={navigateToPath}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/molecules/StepIndicator/step_indicator.module.scss
+++ b/src/molecules/StepIndicator/step_indicator.module.scss
@@ -2,6 +2,12 @@
   display: flex;
 }
 
+.active-step {
+  width: 100%;
+  text-align: center;
+  line-height: 1.5;
+}
+
 .breadcrumb {
   flex: 1;
 
@@ -76,5 +82,19 @@
     &-inactive {
      opacity: 0;
     }
+  }
+
+  .step-title {
+    display: none;
+  }
+
+  .circle-wrapper {
+    margin-left: 40%;
+  }
+}
+
+@media #{$medium-up} {
+  .active-step {
+    display: none;
   }
 }


### PR DESCRIPTION
👀  plz @cisacke @danielnovograd @jmcolella removes step names except for the active step from the progress bar to fix alignment issues. [ch9144](https://app.clubhouse.io/policygenius/story/9144/user-should-see-a-fixed-progress-bar)