### PR TITLE
Fix layout

### DIFF
--- a/src/atoms/Layout/Col/index.js
+++ b/src/atoms/Layout/Col/index.js
@@ -44,6 +44,8 @@ function Col(props) {
   );
 }
 
+Col.rclName = 'COL';
+
 Col.propTypes = {
   /**
    * Supply any additional class names.

--- a/src/atoms/Layout/__tests__/__snapshots__/layout.spec.js.snap
+++ b/src/atoms/Layout/__tests__/__snapshots__/layout.spec.js.snap
@@ -107,6 +107,247 @@ ShallowWrapper {
 }
 `;
 
+exports[`<Layout /> doesn't wrap Cols in \`<Col>\` 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="layout"
+    style={undefined}
+>
+    <Col
+        borderColor="neutral-6"
+        bottomSpacing={undefined}
+        flex={undefined}
+        fullwidth={undefined}
+        largeCols={undefined}
+        mediumCols={undefined}
+        smallCols={1}
+        xLargeCols={undefined}
+        xxLargeCols={undefined}
+    >
+        <div
+            className="child"
+        />
+    </Col>
+    <Col
+        borderColor="neutral-6"
+        bottomSpacing={undefined}
+        className="child"
+        flex={undefined}
+        fullwidth={undefined}
+        largeCols={undefined}
+        mediumCols={undefined}
+        smallCols={1}
+        xLargeCols={undefined}
+        xxLargeCols={undefined}
+    />
+</div>,
+  "nodes": Array [
+    <div
+      className="layout"
+      style={undefined}
+>
+      <Col
+            borderColor="neutral-6"
+            bottomSpacing={undefined}
+            flex={undefined}
+            fullwidth={undefined}
+            largeCols={undefined}
+            mediumCols={undefined}
+            smallCols={1}
+            xLargeCols={undefined}
+            xxLargeCols={undefined}
+      >
+            <div
+                  className="child"
+            />
+      </Col>
+      <Col
+            borderColor="neutral-6"
+            bottomSpacing={undefined}
+            className="child"
+            flex={undefined}
+            fullwidth={undefined}
+            largeCols={undefined}
+            mediumCols={undefined}
+            smallCols={1}
+            xLargeCols={undefined}
+            xxLargeCols={undefined}
+      />
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <Layout
+        largeCols={Array []}
+        mediumCols={Array []}
+        smallCols={
+                Array [
+                        1,
+                      ]
+        }
+        xLargeCols={Array []}
+        xxLargeCols={Array []}
+>
+        <div
+                className="child"
+        />
+        <Col
+                borderColor="neutral-6"
+                className="child"
+        />
+</Layout>,
+      "_debugID": 12,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "children": Array [
+            <div
+              className="child"
+/>,
+            <Col
+              borderColor="neutral-6"
+              className="child"
+/>,
+          ],
+          "largeCols": Array [],
+          "mediumCols": Array [],
+          "smallCols": Array [
+            1,
+          ],
+          "xLargeCols": Array [],
+          "xxLargeCols": Array [],
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 4,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="layout"
+          style={undefined}
+>
+          <Col
+                    borderColor="neutral-6"
+                    bottomSpacing={undefined}
+                    flex={undefined}
+                    fullwidth={undefined}
+                    largeCols={undefined}
+                    mediumCols={undefined}
+                    smallCols={1}
+                    xLargeCols={undefined}
+                    xxLargeCols={undefined}
+          >
+                    <div
+                              className="child"
+                    />
+          </Col>
+          <Col
+                    borderColor="neutral-6"
+                    bottomSpacing={undefined}
+                    className="child"
+                    flex={undefined}
+                    fullwidth={undefined}
+                    largeCols={undefined}
+                    mediumCols={undefined}
+                    smallCols={1}
+                    xLargeCols={undefined}
+                    xxLargeCols={undefined}
+          />
+</div>,
+        "_debugID": 13,
+        "_renderedOutput": <div
+          className="layout"
+          style={undefined}
+>
+          <Col
+                    borderColor="neutral-6"
+                    bottomSpacing={undefined}
+                    flex={undefined}
+                    fullwidth={undefined}
+                    largeCols={undefined}
+                    mediumCols={undefined}
+                    smallCols={1}
+                    xLargeCols={undefined}
+                    xxLargeCols={undefined}
+          >
+                    <div
+                              className="child"
+                    />
+          </Col>
+          <Col
+                    borderColor="neutral-6"
+                    bottomSpacing={undefined}
+                    className="child"
+                    flex={undefined}
+                    fullwidth={undefined}
+                    largeCols={undefined}
+                    mediumCols={undefined}
+                    smallCols={1}
+                    xLargeCols={undefined}
+                    xxLargeCols={undefined}
+          />
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Layout
+    largeCols={Array []}
+    mediumCols={Array []}
+    smallCols={
+        Array [
+            1,
+          ]
+    }
+    xLargeCols={Array []}
+    xxLargeCols={Array []}
+>
+    <div
+        className="child"
+    />
+    <Col
+        borderColor="neutral-6"
+        className="child"
+    />
+</Layout>,
+}
+`;
+
 exports[`<Layout /> passes its \`col\` props down to its \`<Col>\` correctly 1`] = `
 ShallowWrapper {
   "complexSelector": ComplexSelector {
@@ -223,7 +464,7 @@ ShallowWrapper {
                 className="child"
         />
 </Layout>,
-      "_debugID": 12,
+      "_debugID": 14,
       "_hostContainerInfo": null,
       "_hostParent": null,
       "_instance": StatelessComponent {
@@ -267,7 +508,7 @@ ShallowWrapper {
           "validateCallback": [Function],
         },
       },
-      "_mountOrder": 4,
+      "_mountOrder": 5,
       "_pendingCallbacks": null,
       "_pendingElement": null,
       "_pendingForceUpdate": false,
@@ -309,7 +550,7 @@ ShallowWrapper {
                     />
           </Col>
 </div>,
-        "_debugID": 13,
+        "_debugID": 15,
         "_renderedOutput": <div
           className="layout padding"
           style={undefined}
@@ -824,7 +1065,7 @@ ShallowWrapper {
                 className="child"
         />
 </Layout>,
-      "_debugID": 14,
+      "_debugID": 16,
       "_hostContainerInfo": null,
       "_hostParent": null,
       "_instance": StatelessComponent {
@@ -863,7 +1104,7 @@ ShallowWrapper {
           "validateCallback": [Function],
         },
       },
-      "_mountOrder": 5,
+      "_mountOrder": 6,
       "_pendingCallbacks": null,
       "_pendingElement": null,
       "_pendingForceUpdate": false,
@@ -905,7 +1146,7 @@ ShallowWrapper {
                     />
           </Col>
 </div>,
-        "_debugID": 15,
+        "_debugID": 17,
         "_renderedOutput": <div
           className="layout"
           style={undefined}
@@ -1016,14 +1257,9 @@ ShallowWrapper {
         xLargeCols={undefined}
         xxLargeCols={undefined}
     >
-        <Col
-            borderColor="neutral-6"
-            smallCols={3}
-        >
-            <div
-                className="one-off"
-            />
-        </Col>
+        <div
+            className="one-off"
+        />
     </Col>
     <Col
         borderColor="neutral-6"
@@ -1072,14 +1308,9 @@ ShallowWrapper {
             xLargeCols={undefined}
             xxLargeCols={undefined}
       >
-            <Col
-                  borderColor="neutral-6"
-                  smallCols={3}
-            >
-                  <div
-                        className="one-off"
-                  />
-            </Col>
+            <div
+                  className="one-off"
+            />
       </Col>
       <Col
             borderColor="neutral-6"
@@ -1130,7 +1361,7 @@ ShallowWrapper {
                 className="child"
         />
 </Layout>,
-      "_debugID": 16,
+      "_debugID": 18,
       "_hostContainerInfo": null,
       "_hostParent": null,
       "_instance": StatelessComponent {
@@ -1174,7 +1405,7 @@ ShallowWrapper {
           "validateCallback": [Function],
         },
       },
-      "_mountOrder": 6,
+      "_mountOrder": 7,
       "_pendingCallbacks": null,
       "_pendingElement": null,
       "_pendingForceUpdate": false,
@@ -1211,14 +1442,9 @@ ShallowWrapper {
                     xLargeCols={undefined}
                     xxLargeCols={undefined}
           >
-                    <Col
-                              borderColor="neutral-6"
-                              smallCols={3}
-                    >
-                              <div
-                                        className="one-off"
-                              />
-                    </Col>
+                    <div
+                              className="one-off"
+                    />
           </Col>
           <Col
                     borderColor="neutral-6"
@@ -1236,7 +1462,7 @@ ShallowWrapper {
                     />
           </Col>
 </div>,
-        "_debugID": 17,
+        "_debugID": 19,
         "_renderedOutput": <div
           className="layout"
           style={undefined}
@@ -1267,14 +1493,9 @@ ShallowWrapper {
                     xLargeCols={undefined}
                     xxLargeCols={undefined}
           >
-                    <Col
-                              borderColor="neutral-6"
-                              smallCols={3}
-                    >
-                              <div
-                                        className="one-off"
-                              />
-                    </Col>
+                    <div
+                              className="one-off"
+                    />
           </Col>
           <Col
                     borderColor="neutral-6"

--- a/src/atoms/Layout/__tests__/layout.spec.js
+++ b/src/atoms/Layout/__tests__/layout.spec.js
@@ -53,6 +53,18 @@ describe('<Layout />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('doesn\'t wrap Cols in `<Col>`', () => {
+    const wrapper = shallow(
+      <Layout smallCols={[ 1 ]}>
+        <div className='child' />
+        <Col className='child' />
+      </Layout>
+    );
+
+    expect(wrapper.find('Col > Col')).toHaveLength(0);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('passes its `col` props down to its `<Col>` correctly', () => {
     const wrapper = shallow(
       <Layout

--- a/src/atoms/Layout/utils.js
+++ b/src/atoms/Layout/utils.js
@@ -1,10 +1,19 @@
 import React from 'react';
 import omit from 'lodash/omit';
+import get from 'lodash/get';
 import Col from './Col';
 
 export function processChild(child, layoutProps) {
 
-  if (child.type === Col) {
+  // TODO: Find a better way to type check here.
+  // I believe the first now fails because of Preact
+  if (
+    child.type === Col ||
+    get(child, 'nodeName.name') === 'cl' ||
+    get(child, 'type.name') === 'cl' ||
+    get(child, 'type.name') === 'Col' ||
+    get(child, 'type.rclName') === 'Col'
+  ) {
     const colProps = Object.assign(
       {},
       omit(layoutProps, [ 'padding' ]),

--- a/src/molecules/formfields/FieldGroup/__tests__/__snapshots__/field_group.spec.js.snap
+++ b/src/molecules/formfields/FieldGroup/__tests__/__snapshots__/field_group.spec.js.snap
@@ -39,67 +39,55 @@ exports[`<FieldGroup /> renders correctly 1`] = `
       style={undefined}
     >
       <div
-        className="col col-sm-6 fullwidth border-neutral-6"
+        className="col col-sm-6 fullwidth border-neutral-6 field"
         onClick={undefined}
         style={undefined}
       >
-        <div
-          className="col border-neutral-6 field"
-          onClick={undefined}
-          style={undefined}
-        >
-          <div>
-            <div
-              className=""
+        <div>
+          <div
+            className=""
+          >
+            <span
+              className="input-wrapper"
+              data-postfix={undefined}
+              data-prefix={undefined}
             >
-              <span
-                className="input-wrapper"
-                data-postfix={undefined}
-                data-prefix={undefined}
-              >
-                <input
-                  className="input"
-                  id={undefined}
-                  placeholder="mm"
-                  type="text"
-                  value={undefined}
-                />
-              </span>
-            </div>
-            <span />
+              <input
+                className="input"
+                id={undefined}
+                placeholder="mm"
+                type="text"
+                value={undefined}
+              />
+            </span>
           </div>
+          <span />
         </div>
       </div>
       <div
-        className="col col-sm-6 fullwidth border-neutral-6"
+        className="col col-sm-6 fullwidth border-neutral-6 field"
         onClick={undefined}
         style={undefined}
       >
-        <div
-          className="col border-neutral-6 field"
-          onClick={undefined}
-          style={undefined}
-        >
-          <div>
-            <div
-              className=""
+        <div>
+          <div
+            className=""
+          >
+            <span
+              className="input-wrapper"
+              data-postfix={undefined}
+              data-prefix={undefined}
             >
-              <span
-                className="input-wrapper"
-                data-postfix={undefined}
-                data-prefix={undefined}
-              >
-                <input
-                  className="input"
-                  id={undefined}
-                  placeholder="yyyy"
-                  type="text"
-                  value={undefined}
-                />
-              </span>
-            </div>
-            <span />
+              <input
+                className="input"
+                id={undefined}
+                placeholder="yyyy"
+                type="text"
+                value={undefined}
+              />
+            </span>
           </div>
+          <span />
         </div>
       </div>
     </div>

--- a/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
+++ b/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
@@ -49,42 +49,36 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
           style={undefined}
         >
           <div
-            className="col col-sm-4 col-md-5 fullwidth border-neutral-6"
+            className="col col-sm-4 col-md-5 fullwidth border-neutral-6 policy-info-tooltip-group"
             onClick={undefined}
             style={undefined}
           >
-            <div
-              className="col fullwidth border-neutral-6 policy-info-tooltip-group"
-              onClick={undefined}
-              style={undefined}
+            <p
+              className="primary-3 type-b-7-medium"
             >
-              <p
-                className="primary-3 type-b-7-medium"
-              >
-                Financial Strength
-              </p>
+              Financial Strength
+            </p>
+            <span
+              className="tooltip-wrapper policy-info-tooltip-icon"
+              onClick={[Function]}
+            >
               <span
-                className="tooltip-wrapper policy-info-tooltip-icon"
-                onClick={[Function]}
-              >
-                <span
-                  className="icon-wrapper tooltip"
-                  onClick={undefined}
-                  style={
-                    Object {
-                      "height": undefined,
-                      "width": undefined,
-                    }
+                className="icon-wrapper tooltip"
+                onClick={undefined}
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                />
-                <span
-                  className="hover-message"
-                >
-                  <div />
-                </span>
-                <noscript />
+                }
+              />
+              <span
+                className="hover-message"
+              >
+                <div />
               </span>
-            </div>
+              <noscript />
+            </span>
           </div>
           <div
             className="col col-sm-2 col-md-1 border-neutral-6"
@@ -115,42 +109,36 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
           style={undefined}
         >
           <div
-            className="col col-sm-4 col-md-5 fullwidth border-neutral-6"
+            className="col col-sm-4 col-md-5 fullwidth border-neutral-6 policy-info-tooltip-group"
             onClick={undefined}
             style={undefined}
           >
-            <div
-              className="col fullwidth border-neutral-6 policy-info-tooltip-group"
-              onClick={undefined}
-              style={undefined}
+            <p
+              className="primary-3 type-b-7-medium"
             >
-              <p
-                className="primary-3 type-b-7-medium"
-              >
-                Total Customers
-              </p>
+              Total Customers
+            </p>
+            <span
+              className="tooltip-wrapper policy-info-tooltip-icon"
+              onClick={[Function]}
+            >
               <span
-                className="tooltip-wrapper policy-info-tooltip-icon"
-                onClick={[Function]}
-              >
-                <span
-                  className="icon-wrapper tooltip"
-                  onClick={undefined}
-                  style={
-                    Object {
-                      "height": undefined,
-                      "width": undefined,
-                    }
+                className="icon-wrapper tooltip"
+                onClick={undefined}
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                />
-                <span
-                  className="hover-message"
-                >
-                  <div />
-                </span>
-                <noscript />
+                }
+              />
+              <span
+                className="hover-message"
+              >
+                <div />
               </span>
-            </div>
+              <noscript />
+            </span>
           </div>
           <div
             className="col col-sm-2 col-md-1 border-neutral-6"
@@ -181,42 +169,36 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
           style={undefined}
         >
           <div
-            className="col col-sm-4 col-md-5 fullwidth border-neutral-6"
+            className="col col-sm-4 col-md-5 fullwidth border-neutral-6 policy-info-tooltip-group"
             onClick={undefined}
             style={undefined}
           >
-            <div
-              className="col fullwidth border-neutral-6 policy-info-tooltip-group"
-              onClick={undefined}
-              style={undefined}
+            <p
+              className="primary-3 type-b-7-medium"
             >
-              <p
-                className="primary-3 type-b-7-medium"
-              >
-                Policy Type
-              </p>
+              Policy Type
+            </p>
+            <span
+              className="tooltip-wrapper policy-info-tooltip-icon"
+              onClick={[Function]}
+            >
               <span
-                className="tooltip-wrapper policy-info-tooltip-icon"
-                onClick={[Function]}
-              >
-                <span
-                  className="icon-wrapper tooltip"
-                  onClick={undefined}
-                  style={
-                    Object {
-                      "height": undefined,
-                      "width": undefined,
-                    }
+                className="icon-wrapper tooltip"
+                onClick={undefined}
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                />
-                <span
-                  className="hover-message"
-                >
-                  <div />
-                </span>
-                <noscript />
+                }
+              />
+              <span
+                className="hover-message"
+              >
+                <div />
               </span>
-            </div>
+              <noscript />
+            </span>
           </div>
           <div
             className="col col-sm-2 col-md-1 border-neutral-6"

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -49,42 +49,36 @@ exports[`<PolicyCard /> renders correctly 1`] = `
               style={undefined}
             >
               <div
-                className="col col-sm-4 col-md-5 fullwidth border-neutral-6"
+                className="col col-sm-4 col-md-5 fullwidth border-neutral-6 policy-info-tooltip-group"
                 onClick={undefined}
                 style={undefined}
               >
-                <div
-                  className="col fullwidth border-neutral-6 policy-info-tooltip-group"
-                  onClick={undefined}
-                  style={undefined}
+                <p
+                  className="primary-3 type-b-7-medium"
                 >
-                  <p
-                    className="primary-3 type-b-7-medium"
-                  >
-                    label
-                  </p>
+                  label
+                </p>
+                <span
+                  className="tooltip-wrapper policy-info-tooltip-icon"
+                  onClick={[Function]}
+                >
                   <span
-                    className="tooltip-wrapper policy-info-tooltip-icon"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="icon-wrapper tooltip"
-                      onClick={undefined}
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
+                    className="icon-wrapper tooltip"
+                    onClick={undefined}
+                    style={
+                      Object {
+                        "height": undefined,
+                        "width": undefined,
                       }
-                    />
-                    <span
-                      className="hover-message"
-                    >
-                      <div />
-                    </span>
-                    <noscript />
+                    }
+                  />
+                  <span
+                    className="hover-message"
+                  >
+                    <div />
                   </span>
-                </div>
+                  <noscript />
+                </span>
               </div>
               <div
                 className="col col-sm-2 col-md-1 border-neutral-6"
@@ -115,42 +109,36 @@ exports[`<PolicyCard /> renders correctly 1`] = `
               style={undefined}
             >
               <div
-                className="col col-sm-4 col-md-5 fullwidth border-neutral-6"
+                className="col col-sm-4 col-md-5 fullwidth border-neutral-6 policy-info-tooltip-group"
                 onClick={undefined}
                 style={undefined}
               >
-                <div
-                  className="col fullwidth border-neutral-6 policy-info-tooltip-group"
-                  onClick={undefined}
-                  style={undefined}
+                <p
+                  className="primary-3 type-b-7-medium"
                 >
-                  <p
-                    className="primary-3 type-b-7-medium"
-                  >
-                    label
-                  </p>
+                  label
+                </p>
+                <span
+                  className="tooltip-wrapper policy-info-tooltip-icon"
+                  onClick={[Function]}
+                >
                   <span
-                    className="tooltip-wrapper policy-info-tooltip-icon"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="icon-wrapper tooltip"
-                      onClick={undefined}
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
+                    className="icon-wrapper tooltip"
+                    onClick={undefined}
+                    style={
+                      Object {
+                        "height": undefined,
+                        "width": undefined,
                       }
-                    />
-                    <span
-                      className="hover-message"
-                    >
-                      <div />
-                    </span>
-                    <noscript />
+                    }
+                  />
+                  <span
+                    className="hover-message"
+                  >
+                    <div />
                   </span>
-                </div>
+                  <noscript />
+                </span>
               </div>
               <div
                 className="col col-sm-2 col-md-1 border-neutral-6"
@@ -204,44 +192,32 @@ exports[`<PolicyCard /> renders correctly 1`] = `
             style={undefined}
           >
             <div
-              className="col col-sm-6 fullwidth border-neutral-6"
+              className="col col-sm-6 fullwidth border-neutral-6 secondary-action"
               onClick={undefined}
               style={undefined}
             >
-              <div
-                className="col border-neutral-6 secondary-action"
-                onClick={undefined}
-                style={undefined}
+              <button
+                className="button"
+                disabled={undefined}
+                onClick={[Function]}
+                type="button"
               >
-                <button
-                  className="button"
-                  disabled={undefined}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Details
-                </button>
-              </div>
+                Details
+              </button>
             </div>
             <div
-              className="col col-sm-6 fullwidth border-neutral-6"
+              className="col col-sm-6 fullwidth border-neutral-6 secondary-action"
               onClick={undefined}
               style={undefined}
             >
-              <div
-                className="col border-neutral-6 secondary-action"
-                onClick={undefined}
-                style={undefined}
+              <button
+                className="button"
+                disabled={undefined}
+                onClick={[Function]}
+                type="button"
               >
-                <button
-                  className="button"
-                  disabled={undefined}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Compare
-                </button>
-              </div>
+                Compare
+              </button>
             </div>
           </div>
         </div>

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,6 @@
 - [ ] **TODO: Remove this old typography file** : ./src/assets/stylesheets/base_styles/_typography.scss
 - [ ] **TODO: Make this less confusing** : ./src/assets/stylesheets/base_styles/_typography.scss
+- [ ] **TODO: Find a better way to type check here.** : ./src/atoms/Layout/utils.js
 - [ ] **TODO: Write better tests** : ./src/atoms/StyledWrapper/__tests__/styled_wrapper.spec.js
 - [ ] **TODO: Remove 'a' prop as an option from component** : ./src/atoms/Text/index.js
 - [ ] **TODO: This is a hack because Layout isn't correctly passing props** : ./src/static/Footer/styles.js


### PR DESCRIPTION
I’m updating the `Layout` component. It looks like the only thing affected is the footer, but be vigilant. It is correcting the issue of `Layout` double nesting `Col` components when a `Col` is explicitly passed as a child.