### PR TITLE
Remove images when source set to null

### DIFF
--- a/src/atoms/Img/__tests__/__snapshots__/img.spec.js.snap
+++ b/src/atoms/Img/__tests__/__snapshots__/img.spec.js.snap
@@ -1,23 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Img /> renders correctly with default props 1`] = `
-<img
-  alt="photos alexander dummer 150646"
-  className="img"
-  sizes="100vw"
-  src="https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?w=768&h=768&fit=clip&auto=format&auto=compress"
-  srcSet="
-  https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?w=1025&h=1025&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 1026w,
-  https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?w=768&h=768&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 769w,
-  https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?w=320&h=320&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 321w
-"
-  title="photos alexander dummer 150646"
-/>
+<picture
+  className=""
+>
+  <img
+    alt="photos alexander dummer 150646"
+    className="img"
+    src="https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?w=768&h=768&fit=clip&auto=format&auto=compress"
+    title="photos alexander dummer 150646"
+  />
+</picture>
 `;
 
 exports[`<Img /> renders correctly with given imgix picture source props 1`] = `
 <picture
-  className={undefined}
+  className=""
 >
   <source
     media="(max-width: 767px)"
@@ -38,23 +36,21 @@ exports[`<Img /> renders correctly with given imgix picture source props 1`] = `
 `;
 
 exports[`<Img /> renders correctly with given imgix props 1`] = `
-<img
-  alt="photos are cool"
-  className="img cool-class"
-  sizes="100vw"
-  src="https://policygenius-images.imgix.net/photos/are-cool.jpg?w=768&h=768&fit=clip&auto=format&auto=compress"
-  srcSet="
-  https://policygenius-images.imgix.net/photos/are-cool.jpg?w=10&h=20&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 1026w,
-  https://policygenius-images.imgix.net/photos/are-cool.jpg?w=10&h=20&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 769w,
-  https://policygenius-images.imgix.net/photos/are-cool.jpg?w=10&h=20&fit=clip&auto=compress&auto=format&ch=Width,DPR,Save-Data 321w
-"
-  title="photos are cool"
-/>
+<picture
+  className="cool-class"
+>
+  <img
+    alt="photos are cool"
+    className="img"
+    src="https://policygenius-images.imgix.net/photos/are-cool.jpg?w=768&h=768&fit=clip&auto=format&auto=compress"
+    title="photos are cool"
+  />
+</picture>
 `;
 
 exports[`<Img /> renders correctly with given regular picture source props 1`] = `
 <picture
-  className={undefined}
+  className=""
 >
   <source
     media="(max-width: 767px)"
@@ -75,12 +71,28 @@ exports[`<Img /> renders correctly with given regular picture source props 1`] =
 `;
 
 exports[`<Img /> renders correctly with given regular props 1`] = `
-<img
-  alt="alt"
-  className="img cool-class"
-  sizes="100vw"
-  src="some-url"
-  srcSet="some-url"
-  title="title"
-/>
+<picture
+  className="cool-class"
+>
+  <img
+    alt="alt"
+    className="img"
+    src="some-url"
+    title="title"
+  />
+</picture>
+`;
+
+exports[`<Img /> renders with hide classes when null src props are provided 1`] = `
+<picture
+  className="hide-mobile-image hide-tablet-image"
+>
+  <img
+    alt="default"
+    className="img"
+    desktopImgixSrc="large"
+    src="https://policygenius-images.imgix.net/default?w=768&h=768&fit=clip&auto=format&auto=compress"
+    title="default"
+  />
+</picture>
 `;

--- a/src/atoms/Img/__tests__/img.spec.js
+++ b/src/atoms/Img/__tests__/img.spec.js
@@ -72,4 +72,17 @@ describe('<Img />', () => {
 
     expect(actual).toMatchSnapshot();
   });
+
+  it('renders with hide classes when null src props are provided', () => {
+    const props = {
+      mobileImgixSrc: null,
+      tabletImgixSrc: null,
+      desktopImgixSrc: 'large',
+      imgixSrc: 'default'
+    };
+
+    const actual = renderer.create(<Img {...props} />).toJSON();
+
+    expect(actual).toMatchSnapshot();
+  });
 });

--- a/src/atoms/Img/img.module.scss
+++ b/src/atoms/Img/img.module.scss
@@ -1,3 +1,16 @@
 .img {
   max-width: 100%;
 }
+
+@media #{$mobile-only} {
+  .hide-mobile-image {
+    display: none;
+  }
+}
+
+@media #{$tablet-only} {
+  .hide-tablet-image {
+    display: none;
+  }
+}
+

--- a/src/atoms/Img/index.js
+++ b/src/atoms/Img/index.js
@@ -37,13 +37,19 @@ function Img(props) {
     ...rest
   } = props;
 
-  const isPicture = mobileSrc ||
-    tabletSrc ||
-    mobileImgixSrc ||
-    tabletImgixSrc;
+  const isPicture = mobileSrc === undefined ||
+    tabletSrc === undefined ||
+    mobileImgixSrc === undefined ||
+    tabletImgixSrc === undefined;
 
   const classes = cx(
     styles['img'],
+    className,
+  );
+
+  const pictureClasses = cx(
+    (mobileImgixSrc === null || mobileSrc === null) && styles['hide-mobile-image'],
+    (tabletImgixSrc === null || tabletSrc === null) && styles['hide-tablet-image'],
     className,
   );
 
@@ -58,7 +64,7 @@ function Img(props) {
     const defaultSrc = src || imgixSrcStr(imgixSrc);
 
     return (
-      <picture className={className}>
+      <picture className={pictureClasses}>
         { ( mobileImgixSrc || mobileSrc ) && <source srcSet={mobileSrc || imgixSrcStr(mobileImgixSrc, 767)} media='(max-width: 767px)' />}
         { ( tabletImgixSrc || tabletSrc ) && <source srcSet={tabletSrc || imgixSrcStr(tabletImgixSrc, 1024)} media='(max-width: 1024px)' />}
         <img
@@ -130,19 +136,23 @@ Img.propTypes = {
   maxHeight: PropTypes.string,
 
   /**
-   * When used, will create a <source> for a <picture> element for mobile
+   * When used, will create a <source> for a <picture> element for mobile.
+   * If null, the image will not display on mobile
    */
   mobileSrc: PropTypes.string,
   /**
    * When used, will create a <source> for a <picture> element for tablet
+   * If null, the image will not display on tablet
    */
   tabletSrc: PropTypes.string,
   /**
    * Alternate image for mobile. When used, will create a <source> for a <picture> element for mobile. Will use imgix custom string.
+   * If null, the image will not display on mobile
    */
   mobileImgixSrc: PropTypes.string,
   /**
    * Alternate image for tablet. When used, will create a <source> for a <picture> element for tablet. Will use imgix. Will use imgix custom string.
+   * If null, the image will not display on tablet
    */
   tabletImgixSrc: PropTypes.string,
 };


### PR DESCRIPTION
`<Img />` component can now take in null sources for tablet and mobile, causing it to display none for those screen sizes.