### PR TITLE
Switch policy cards to default to continue CTA

### DIFF
--- a/src/organisms/cards/FeaturedPolicyCard/ButtonGroup.js
+++ b/src/organisms/cards/FeaturedPolicyCard/ButtonGroup.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from 'atoms/Button';
+import LinkWrapper from 'atoms/LinkWrapper';
 import Spacer from 'atoms/Spacer';
 
 import styles from './featured_policy_card.module.scss';
@@ -9,16 +10,31 @@ import styles from './featured_policy_card.module.scss';
 function ButtonGroup(props) {
   const {
     onDetails,
+    onContinue,
     onCompare,
+    continueCTAText,
+    detailsCTAText,
   } = props;
 
   return (
     <div className={styles['button-group']}>
       <Button
-        onClick={onDetails}
+        onClick={onContinue}
       >
-        View Policy
+        {continueCTAText}
       </Button>
+      {
+        onDetails &&
+          <div>
+            <LinkWrapper
+              onClick={onDetails}
+              className={styles['details-link']}
+            >
+              {detailsCTAText}
+            </LinkWrapper>
+          </div>
+
+      }
       {
         onCompare &&
         <div>
@@ -36,8 +52,16 @@ function ButtonGroup(props) {
 }
 
 ButtonGroup.propTypes = {
-  onDetails: PropTypes.func.isRequired,
-  onCompare: PropTypes.func
+  onContinue: PropTypes.func.isRequired,
+  onDetails: PropTypes.func,
+  onCompare: PropTypes.func,
+  continueCTAText: PropTypes.string,
+  detailsCTAText: PropTypes.string,
+};
+
+ButtonGroup.defaultProps = {
+  continueCTAText: 'Continue',
+  detailsCTAText: 'Details',
 };
 
 export default ButtonGroup;

--- a/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
+++ b/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
@@ -214,8 +214,16 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
         onClick={[Function]}
         type="button"
       >
-        View Policy
+        Continue
       </button>
+      <div>
+        <a
+          className="link neutral-1 details-link"
+          onClick={[Function]}
+        >
+          Details
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/organisms/cards/FeaturedPolicyCard/index.js
+++ b/src/organisms/cards/FeaturedPolicyCard/index.js
@@ -12,16 +12,17 @@ import PolicyInformation from './PolicyInformation';
 
 function FeaturedPolicyCard(props) {
   const {
-    className,
-    header,
-    premium,
-    discount,
     carrierLogo,
-    onDetails,
-    information,
-    onCompare,
+    className,
     continueCTAText,
+    discount,
+    header,
+    information,
+    onContinue,
+    onDetails,
+    onCompare,
     policyHat,
+    premium,
   } = props;
 
   const classes = [
@@ -70,6 +71,7 @@ function FeaturedPolicyCard(props) {
         { information && <PolicyInformation information={information} /> }
 
         <ButtonGroup
+          onContinue={onContinue}
           onDetails={onDetails}
           onCompare={onCompare}
           continueCTAText={continueCTAText}
@@ -124,6 +126,11 @@ FeaturedPolicyCard.propTypes = {
   /**
    * Function supplied to details link below CTA
    */
+  onContinue: PropTypes.func.isRequired,
+
+  /**
+   * Function supplied to details link below CTA
+   */
   onDetails: PropTypes.func,
 
   /**
@@ -150,6 +157,7 @@ FeaturedPolicyCard.propTypes = {
 
 FeaturedPolicyCard.defaultProps = {
   continueCTAText: 'Continue',
+  detailsCTAText: 'Details & Review',
   policyHat: false
 };
 

--- a/src/organisms/cards/PolicyCard/PolicyActions.js
+++ b/src/organisms/cards/PolicyCard/PolicyActions.js
@@ -23,7 +23,7 @@ export const PolicyActions = (props) => {
   const {
     premium,
     discount,
-    onDetails,
+    onContinue,
     onCompare
   } = props;
 
@@ -45,8 +45,8 @@ export const PolicyActions = (props) => {
       }
       <Spacer spacer={3} />
       <Layout smallCols={[ 12 ]} style={{ width: '100%' }}>
-        <Button onClick={onDetails} className={styles['view-policy']}>
-          View Policy
+        <Button onClick={onContinue} className={styles['view-policy']}>
+          Continue
         </Button>
         <Hide hideOn='tablet desktop'>
           <Button
@@ -67,7 +67,7 @@ PolicyActions.propTypes = {
     defaultText: PropTypes.node,
   }),
   discount: PropTypes.node,
-  onDetails: PropTypes.func,
+  onContinue: PropTypes.func,
   onCompare: PropTypes.func,
 };
 

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -164,8 +164,16 @@ exports[`<PolicyCard /> renders correctly 1`] = `
             onClick={[Function]}
             type="button"
           >
-            View Policy
+            Continue
           </button>
+          <div>
+            <a
+              className="link neutral-1 details-link"
+              onClick={[Function]}
+            >
+              Details
+            </a>
+          </div>
           <div>
             <div
               className="top-2"
@@ -444,7 +452,7 @@ exports[`<PolicyCard /> renders correctly 1`] = `
               onClick={[Function]}
               type="button"
             >
-              View Policy
+              Continue
             </button>
           </div>
           <div

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/ButtonGroup.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/ButtonGroup.js
@@ -2,25 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from 'atoms/Button';
+import LinkWrapper from 'atoms/LinkWrapper';
 import Spacer from 'atoms/Spacer';
 
 import styles from './featured_policy_card.module.scss';
 
 function ButtonGroup(props) {
   const {
+    onContinue,
     onDetails,
     onCompare,
+    continueCTAText,
+    detailsCTAText,
   } = props;
 
   return (
     <div className={styles['button-group']}>
       <Button
-        onClick={onDetails}
+        onClick={onContinue}
       >
-        View Policy
+        {continueCTAText}
       </Button>
 
       <Spacer spacer={2} />
+      {
+        onDetails &&
+          <LinkWrapper
+            onClick={onDetails}
+            className={styles['details-link']}
+          >
+            {detailsCTAText}
+          </LinkWrapper>
+
+      }
 
       <Button outline onClick={onCompare} >
         Compare
@@ -30,8 +44,16 @@ function ButtonGroup(props) {
 }
 
 ButtonGroup.propTypes = {
+  onContinue: PropTypes.func.isRequired,
   onDetails: PropTypes.func,
   onCompare: PropTypes.func,
+  continueCTAText: PropTypes.string,
+  detailsCTAText: PropTypes.string,
+};
+
+ButtonGroup.defaultProps = {
+  continueCTAText: 'Continue',
+  detailsCTAText: 'Details',
 };
 
 export default ButtonGroup;

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/__snapshots__/simple_featured_policy_card.spec.js.snap
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/__snapshots__/simple_featured_policy_card.spec.js.snap
@@ -39,14 +39,20 @@ exports[`<SimpleFeaturedPolicyCard /> renders correctly 1`] = `
       <button
         className="button"
         disabled={undefined}
-        onClick={[Function]}
+        onClick={undefined}
         type="button"
       >
-        View Policy
+        Continue
       </button>
       <div
         className="top-2"
       />
+      <a
+        className="link neutral-1 details-link"
+        onClick={[Function]}
+      >
+        Details
+      </a>
       <button
         className="button outline"
         disabled={undefined}

--- a/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
+++ b/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
@@ -43,14 +43,20 @@ exports[`<SimplePolicyCard /> renders correctly 1`] = `
           <button
             className="button"
             disabled={undefined}
-            onClick={[Function]}
+            onClick={undefined}
             type="button"
           >
-            View Policy
+            Continue
           </button>
           <div
             className="top-2"
           />
+          <a
+            className="link neutral-1 details-link"
+            onClick={[Function]}
+          >
+            Details
+          </a>
           <button
             className="button outline"
             disabled={undefined}


### PR DESCRIPTION
👀  @cisacke @danielnovograd @jmcolella [13762](https://app.clubhouse.io/policygenius/story/13762/shoppers-should-see-an-old-pre-app-experience) Switches the policy cards back to "continue" as the CTA. Also tweaked the component props to make it easier to add a details link back in the future.