### PR TITLE
Col spreads props into first child div

### DIFF
--- a/src/atoms/Layout/Col/index.js
+++ b/src/atoms/Layout/Col/index.js
@@ -16,10 +16,9 @@ function Col(props) {
     padding,
     fullwidth,
     flex,
-    style,
     bottomSpacing,
-    onClick,
-    borderColor
+    borderColor,
+    ...rest
   } = props;
 
   const classes = [
@@ -38,7 +37,7 @@ function Col(props) {
   ];
 
   return (
-    <div className={classnames(...classes)} style={style} onClick={onClick}>
+    <div {...rest} className={classnames(...classes)}>
       { children }
     </div>
   );


### PR DESCRIPTION
To toggle on and off different sections of a page, Optimizely needs to
be able to find certain items using Jquery. In Gatsby, we added a `data`
prop to certain form elements. This prop was getting swallowed by `Col`.
This PR stops `data-*` (and other props, including, but not limited to,
ID) from disappearing into the abyss.