### PR TITLE
Background blocks and gray boxes

### DIFF
--- a/src/assets/stylesheets/_global.scss
+++ b/src/assets/stylesheets/_global.scss
@@ -3,5 +3,6 @@
 @import 'assets/stylesheets/utilities/functions';
 @import 'assets/stylesheets/utilities/mixins';
 @import 'assets/stylesheets/utilities/break_points';
+@import 'assets/stylesheets/utilities/variables';
 @import 'assets/stylesheets/utilities/placeholders';
 @import 'assets/stylesheets/base_styles/spacing';

--- a/src/assets/stylesheets/utilities/_break_points.scss
+++ b/src/assets/stylesheets/utilities/_break_points.scss
@@ -42,3 +42,5 @@ $xxlarge-only: '#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (m
 $small-and-medium-only: '#{$screen} and (max-width: #{upper-bound($tablet-range)})';
 $medium-up-to-large: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($desktop-range)})';
 $medium-up-to-xxlarge: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($xlarge-range)})';
+
+$IE: 'all and (-ms-high-contrast: none), (-ms-high-contrast: active)';

--- a/src/assets/stylesheets/utilities/_mixins.scss
+++ b/src/assets/stylesheets/utilities/_mixins.scss
@@ -1,3 +1,13 @@
+@mixin g-unit($cols: 1, $total-col-count: 12) {
+  $width: calc( ( #{$cols} / #{$total-col-count} ) * 100%);
+
+  width: $width;
+  flex-basis: $width;
+  max-width: $width;
+  flex-grow: 0;
+  flex-shrink: 1;
+}
+
 @mixin hover($background-color, $border-color, $color) {
   &:hover,
   &:active,

--- a/src/assets/stylesheets/utilities/_variables.scss
+++ b/src/assets/stylesheets/utilities/_variables.scss
@@ -1,0 +1,10 @@
+// Use to compensate for scroll-to offset
+// This is the height of the main nav from mobile up
+$tablet-nav-height: 120px;
+
+$gutter-width: rem-calc(12);
+
+// -12px added to take into account gutter that comes with Layout in each section
+$section-padding-mobile: rem-calc(24px - 12px);
+$section-padding-tablet: rem-calc(48px - 12px);
+$section-padding-desktop: rem-calc(64px - 12px);

--- a/src/atoms/Color/colors.scss
+++ b/src/atoms/Color/colors.scss
@@ -2,4 +2,9 @@
   .#{$key} { color: $value; }
   .background-#{$key} { background-color: $value; }
   .border-#{$key} { border-color: $value; }
+  .color-dash-#{$key} {
+    &:after {
+      border-left: rem-calc(3) solid $value;
+    }
+  }
 }

--- a/src/atoms/GrayBox/gray-box.module.scss
+++ b/src/atoms/GrayBox/gray-box.module.scss
@@ -1,0 +1,111 @@
+@mixin g-unit($cols: 1, $total-col-count: 12) {
+  $width: calc( ( #{$cols} / #{$total-col-count} ) * 100%);
+
+  width: $width;
+  flex-basis: $width;
+  max-width: $width;
+  flex-grow: 0;
+  flex-shrink: 1;
+}
+
+.gray-box {
+  position: relative;
+  padding: rem-calc(36) 0;
+
+  > div {
+    position: relative;
+  }
+
+  div:first-child {
+    @media #{$tablet} {
+      margin-left: calc(100% / 12);
+    }
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    display: block;
+    height: rem-calc(110);
+    top: rem-calc(-70);
+    margin-bottom: rem-calc(-110);
+    right: calc(100% / 12);
+
+    @media #{$mobile-only} {
+      height: rem-calc(60);
+      top: rem-calc(-40);
+    }
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    display: block;
+    top: 0;
+    bottom: 0;
+    background-color: color('neutral-3');
+    box-sizing: content-box;
+  }
+
+  @media #{$tablet} {
+    &.right {
+      div:first-child {
+        margin-left: auto;
+      }
+
+      &:before {
+        padding-right: #{$section-padding-desktop};
+        right: -#{$section-padding-desktop};
+      }
+
+      &:after {
+        right: 0;
+      }
+    }
+
+    &.left {
+      div:first-child {
+        margin-left: 0;
+      }
+
+      &:before {
+        left: -#{$section-padding-desktop};
+        padding-left: #{$section-padding-desktop};
+      }
+    }
+  }
+}
+
+@for $i from 1 through 12 {
+  .gray-box-lg-#{$i} {
+    &:before {
+      @include g-unit($i);
+    }
+
+    // Make color dash 1 column to the left of grey box right side
+    &:after {
+      right: calc(100% / 12 * (#{12 - $i + 1}));
+
+      @media #{$mobile-only} {
+        right: 100%;
+      }
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .gray-box {
+    &:before {
+      min-width: 100vw;
+      transform: translateX(-50%);
+      left: 50%;
+      content: '';
+      position: absolute;
+      display: block;
+      top: 0;
+      bottom: 0;
+      background-color: color('neutral-3');
+    }
+  }
+}

--- a/src/atoms/GrayBox/index.js
+++ b/src/atoms/GrayBox/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import Layout from 'atoms/Layout';
+import StyledWrapper from 'atoms/StyledWrapper';
+import Col from 'atoms/Layout/Col';
+import colors from 'atoms/Color/colors.scss';
+
+import styles from './gray-box.module.scss';
+
+const GrayBox = ({
+  cols,
+  variant,
+  colorDash,
+  children,
+  verticalPadding,
+  leftOffset
+}) => {
+  const classes = cx(
+    styles['gray-box'],
+    styles[`gray-box-lg-${cols}`],
+    variant && styles[variant],
+    colorDash && colors[`color-dash-${colorDash}`],
+    leftOffset && styles[`offset-${leftOffset}`]
+  );
+
+  const styleOverrides = ({ breakpoints }) => {
+    let str = '';
+
+    if (verticalPadding) {
+      str += `
+        padding-top: ${verticalPadding};
+        padding-bottom: ${verticalPadding};
+      `;
+    }
+
+    if (leftOffset) {
+      str += `
+      @media ${breakpoints.mediumUp} {
+        margin-left: ${(100 / 12) * leftOffset}% !important;
+        max-width: ${100 - ((100 / 12) * (cols - leftOffset))}% !important;
+      }
+      `;
+    }
+
+    return str;
+  };
+
+  return (
+    <Layout
+      mediumCols={[ cols - 1 ]}
+      className={classes}
+    >
+      <StyledWrapper css={styleOverrides} component={Col}>
+        {children}
+      </StyledWrapper>
+    </Layout>
+  );
+};
+
+GrayBox.propTypes = {
+  supertitle: PropTypes.string,
+  title: PropTypes.string,
+  cols: PropTypes.number,
+  variant: PropTypes.string,
+  colorDash: PropTypes.string,
+  children: PropTypes.node,
+  verticalPadding: PropTypes.string,
+  leftOffset: PropTypes.number
+};
+
+export default GrayBox;

--- a/src/atoms/Layout/Readme.md
+++ b/src/atoms/Layout/Readme.md
@@ -142,3 +142,4 @@ All child component props will be passed directly to the component itself.
   <div>'Child 5'</div>
 </Layout>
 ```
+

--- a/src/atoms/Layout/layout.module.scss
+++ b/src/atoms/Layout/layout.module.scss
@@ -1,16 +1,5 @@
-$gutter-width: ru(.5);
 $border: 1px solid;
 $spacer-base: .25;
-
-@mixin g-unit($cols: 1, $total-col-count: 12) {
-  $width: calc( ( #{$cols} / #{$total-col-count} ) * 100%);
-
-  width: $width;
-  flex-basis: $width;
-  max-width: $width;
-  flex-grow: 0;
-  flex-shrink: 1;
-}
 
 @mixin createCols( $size ) {
   @for $i from 1 through 12 {

--- a/src/molecules/BlockHeader/Readme.md
+++ b/src/molecules/BlockHeader/Readme.md
@@ -1,0 +1,45 @@
+## BlockHeader
+## Default:
+```jsx
+  <BlockHeader
+    cols={10}
+    colorDash='secondary-1'
+    supertitle='Super title dawg'
+    title='Title dawg'
+  />
+```
+
+## Fixed right with vertical padding:
+```jsx
+  <BlockHeader
+    cols={7}
+    supertitle='Super title dawg'
+    colorDash='primary-3'
+    title='Title dawg'
+    variant='right'
+    verticalPadding='60px'
+  />
+```
+
+## Fixed left:
+```jsx
+  <BlockHeader
+    cols={7}
+    supertitle='Super title dawg'
+    title='Title dawg'
+    variant='left'
+  />
+```
+
+## Offset columns
+**Note** leftOffset uses the `StyledWrapper` component, which can lead to buggy behavior
+if the props are expected to change. More advanced usage may require a refactor of this component.
+```jsx
+  <BlockHeader
+    cols={10}
+    leftOffset={5}
+    colorDash='primary-3'
+    supertitle='Super title dawg'
+    title='Title dawg'
+  />
+```

--- a/src/molecules/BlockHeader/index.js
+++ b/src/molecules/BlockHeader/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import GrayBox from 'atoms/GrayBox';
+
+const BlockHeader = ({
+  supertitle,
+  title,
+  cols,
+  variant,
+  colorDash,
+  leftOffset,
+  verticalPadding
+}) =>
+  <GrayBox
+    cols={cols}
+    variant={variant}
+    colorDash={colorDash}
+    leftOffset={leftOffset}
+    verticalPadding={verticalPadding}
+  >
+    <Text variant='label'>
+      {supertitle}
+    </Text>
+    <Text font='a' size={2}>
+      {title}
+    </Text>
+  </GrayBox>;
+
+BlockHeader.propTypes = {
+  /**
+   * The small title above the main title
+  */
+  supertitle: PropTypes.string,
+  /**
+   * The main title
+  */
+  title: PropTypes.string,
+  /**
+   * How many columns the grey box spans
+  */
+  cols: PropTypes.number,
+  /**
+   * `left` or `right` fixed to the side of the section
+  */
+  variant: PropTypes.string,
+  /**
+   * Color of the color dash, e.g. "primary-1" or "secondary-2"
+  */
+  colorDash: PropTypes.string,
+  /**
+   * How much padding to have between titles and gray box in pixels e.g. `"12px"`
+  */
+  verticalPadding: PropTypes.string,
+  /**
+   * Number of columns to push the title to the right, eg `3`
+  */
+  leftOffset: PropTypes.number
+};
+
+export default BlockHeader;

--- a/table_of_contents/engineering.js
+++ b/table_of_contents/engineering.js
@@ -32,6 +32,7 @@ module.exports = {
           components: () => [
             'src/molecules/HeaderDiscount/index.js',
             'src/molecules/HeaderAmount/index.js',
+            'src/molecules/BlockHeader/index.js',
           ]
         },
         {


### PR DESCRIPTION
Since the gray box is a central part of the new branding, we made it
reusable here. A few caveats: the `GrayBox` is an extension of `Layout`,
and the `verticalPadding` and `leftOffset` variants use `StyledWrapper`
which can behave strangely with advanced usage. These features work best
when the props for offset/ padding are not going to change at runtime.