### PR TITLE
Fix featured policy card logo IE

### DIFF
--- a/src/assets/stylesheets/utilities/_break_points.scss
+++ b/src/assets/stylesheets/utilities/_break_points.scss
@@ -44,3 +44,4 @@ $medium-up-to-large: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) a
 $medium-up-to-xxlarge: '#{$screen} and (min-width:#{lower-bound($tablet-range)}) and (max-width:#{upper-bound($xlarge-range)})';
 
 $IE: 'all and (-ms-high-contrast: none), (-ms-high-contrast: active)';
+$IE-mobile: 'all and (max-width: #{upper-bound($mobile-range)}) and (-ms-high-contrast: none), (-ms-high-contrast: active)';

--- a/src/organisms/cards/FeaturedPolicyCard/featured_policy_card.module.scss
+++ b/src/organisms/cards/FeaturedPolicyCard/featured_policy_card.module.scss
@@ -146,3 +146,11 @@ $content-margin-top: ru(.5);
     display: none;
   }
 }
+
+@media #{$IE} {
+  .carrier-logo {
+    img {
+      max-width: inherit;
+    }
+  }
+}


### PR DESCRIPTION
IE hates letting flexed images be themselves in their little containers. This keeps them in the box to which they belong.
[Ticket 14829](https://app.clubhouse.io/policygenius/story/14829/the-spousal-modal-for-ie-11-user-should-not-have-large-icons)
@jmcolella 