### PR TITLE
Update step indicator and footer for life-web

### DIFF
--- a/src/molecules/StepIndicator/index.js
+++ b/src/molecules/StepIndicator/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import get from 'lodash/get';
 import classnames from 'classnames';
-import Text from 'atoms/Text';
 import ProgressBarStep from './ProgressBarStep';
 import styles from './step_indicator.module.scss';
 
@@ -13,13 +11,8 @@ function StepIndicator(props) {
     navigateToPath
   } = props;
 
-  const activeStep = steps.find(step => step.currentStepActive) || steps[0];
-
   return (
     <div className={classnames(className)}>
-      <Text tag='div' type={11} color='primary-3' font='a' spaced className={styles['active-step']}>
-        {get(activeStep, 'text', '')}
-      </Text>
       <div className={styles['step-indicator']}>
         {steps.map((step, idx) =>
           <ProgressBarStep

--- a/src/molecules/StepIndicator/step_indicator.module.scss
+++ b/src/molecules/StepIndicator/step_indicator.module.scss
@@ -92,17 +92,7 @@
     }
   }
 
-  .step-title {
-    display: none;
-  }
-
   .circle-wrapper {
     margin-left: 40%;
-  }
-}
-
-@media #{$medium-up} {
-  .active-step {
-    display: none;
   }
 }

--- a/src/templates/Footer/footer.module.scss
+++ b/src/templates/Footer/footer.module.scss
@@ -4,6 +4,16 @@
   &-layout {
     padding: 0 ru(1) ru(1) ru(1);
   }
+
+  &-layout-constrain {
+    margin: 0 auto;
+    max-width: rem-calc(1280px);
+  }
+}
+
+.phone-lockup {
+  padding-left: 0;
+  padding-right: rem-calc(12px);
 }
 
 .actions {
@@ -130,7 +140,7 @@
 
 @media #{$desktop} {
   .footer-layout {
-    padding-left: 64px;
-    padding-right: 64px;
+    padding-left: rem-calc(64px);
+    padding-right: rem-calc(64px);
   }
 }

--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -41,55 +41,53 @@ function renderPhoneInfo(phoneNumber, hours) {
   if (!phoneNumber) { return null; }
 
   return (
-    <div>
-      <Col className={styles['lockup']}>
-        <LinkWrapper
-          href={`tel:${formatPhoneNumber(phoneNumber)}`}
-          className={classnames(styles['icon-text-wrapper'], styles['link'])}
-          type='resource'
+    <Col className={styles['phone-lockup']}>
+      <LinkWrapper
+        href={`tel:${formatPhoneNumber(phoneNumber)}`}
+        className={classnames(styles['icon-text-wrapper'], styles['link'])}
+        type='resource'
+      >
+        <Icon
+          icon='phone'
+          width='24px'
+          height='24px'
+          className={styles['icon']}
+        />
+
+        <Text
+          size={8}
+          font='a'
         >
-          <Icon
-            icon='phone'
-            width='24px'
-            height='24px'
-            className={styles['icon']}
-          />
-
-          <Text
-            size={8}
-            font='a'
-          >
-            {phoneNumber}
-          </Text>
-        </LinkWrapper>
-
-        <div className={styles['mobile-questions']}>
-          <Spacer size={36} />
-          <Text
-            size={7}
-            font='a'
-          >
-          Questions?
+          {phoneNumber}
         </Text>
-        </div>
+      </LinkWrapper>
 
-        <Spacer size={6} />
+      <div className={styles['mobile-questions']}>
+        <Spacer size={36} />
+        <Text
+          size={7}
+          font='a'
+        >
+        Questions?
+      </Text>
+      </div>
 
-        <div className={styles['hours']}>
-          {
-          hours &&
-          hours.map(hour =>
-            <Text
-              size={10}
-              font='b'
-            >
-              {hour}
-            </Text>
-          )
-        }
-        </div>
-      </Col>
-    </div>
+      <Spacer size={6} />
+
+      <div className={styles['hours']}>
+        {
+        hours &&
+        hours.map(hour =>
+          <Text
+            size={10}
+            font='b'
+          >
+            {hour}
+          </Text>
+        )
+      }
+      </div>
+    </Col>
   );
 }
 
@@ -101,12 +99,18 @@ function Footer(props) {
     links,
     onClickChat,
     hours,
+    constrainWidth
   } = props;
+
+  const layoutClasses = classnames(
+    styles['footer-layout'],
+    constrainWidth && styles['footer-layout-constrain']
+  );
 
   return (
     <div className={classnames(styles['footer'], className)}>
       <Layout
-        className={styles['footer-layout']}
+        className={layoutClasses}
         smallCols={[ 12 ]}
         mediumCols={[ 4 ]}
         fullwidth
@@ -238,6 +242,11 @@ Footer.propTypes = {
    * Sets the Policygenius hours. Each item in the array is displayed as a new line
    */
   hours: PropTypes.array,
+
+  /**
+   * constrains Footer to 1280px and centers content
+   */
+  constrainWidth: PropTypes.bool,
 };
 
 Footer.defaultProps = {


### PR DESCRIPTION
@trevornelson CR please

[CH 13778](https://app.clubhouse.io/policygenius/story/13778/user-should-see-updated-headers-and-footers-throughout-the-life-flow)

- Updates `StepIndicator` to not center active step on mobile
- Updates `Footer` and adds conditional constraint to allow for flexibility when displaying Footer on larger screens

This PR does not include updates needed for the tablet Footer version. That is in a separate ticket and will be updated accordingly.