### PR TITLE
Fix image issue in company card

### DIFF
--- a/src/organisms/cards/CompanyCard/Readme.md
+++ b/src/organisms/cards/CompanyCard/Readme.md
@@ -5,7 +5,7 @@
       starRating={3}
       linkUrl="https://companycard.com"
       imageAttr={{
-      src: "https://cdn.policygenius.com/assets/insurance-cards-logos/aig-dark-07c1cd0ae0d9476ca93abf9b597e43cb.png"
+        src: "https://cdn.policygenius.com/assets/insurance-cards-logos/aig-dark-07c1cd0ae0d9476ca93abf9b597e43cb.png"
       }}
       variant='small'
     />

--- a/src/organisms/cards/CompanyCard/company_card.module.scss
+++ b/src/organisms/cards/CompanyCard/company_card.module.scss
@@ -14,25 +14,25 @@
   background: color('primary-2');
 }
 
-.image-wrapper {
-  margin-bottom: rem-calc(12px);
-
-  img {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 100%;
-    max-height: 100%;
-  }
+.image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: rem-calc(120px);
+  max-height: rem-calc(36px);
 }
 
 .small {
   height: rem-calc(135px);
-  padding: rem-calc(36px 18px);
+  padding: rem-calc(36px) rem-calc(18px);
 
-  .image-wrapper {
+  .image {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: rem-calc(12px);
     max-width: rem-calc(120px);
-    width: auto;
+    max-height: rem-calc(36px);
   }
 
   .star-rating {
@@ -42,12 +42,15 @@
 
 .large {
   height: rem-calc(180px);
-  padding: (60px 36px);
+  padding: rem-calc(60px) rem-calc(36px);
 
-  .image-wrapper {
+  .image {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
     margin-bottom: rem-calc(18px);
-    width: auto;
     max-width: rem-calc(120px);
+    max-height: rem-calc(60px);
   }
 
   .star-rating {

--- a/src/organisms/cards/CompanyCard/index.js
+++ b/src/organisms/cards/CompanyCard/index.js
@@ -35,8 +35,8 @@ const CompanyCard = (props) => {
 
   return (
     <div className={classes}>
-      <div className={styles['image-wrapper']}>
-        <img src={imageAttr.src} role='presentation' />
+      <div>
+        <img className={styles.image} src={imageAttr.src} role='presentation' />
       </div>
       { starRating && <StarRating className={styles['star-rating']} rating={starRating} size={size} /> }
       { linkUrl && <ReadLink linkUrl={linkUrl} /> }


### PR DESCRIPTION
Sometimes images were not being displayed in the company card. They were being downloaded to the browser but the container div around would have a 0px height. 
Adding a specific height to the `img` tag instead of the wrapping parent seems to fix this. 