### PR TITLE
Remove lazysizes from Img export

### DIFF
--- a/src/atoms/Img/Readme.md
+++ b/src/atoms/Img/Readme.md
@@ -1,6 +1,6 @@
 ## Important Info:
 - The `<Img />` component is unusual in that it doesn't automatically fill its parent container - it only has a max-width of 100%, but it will not automatically grow to fit its parent.
-- Images rendered with this component will be lazyloaded automatically via [lazySizes](https://github.com/aFarkas/lazysizes)
+- Images rendered with this component will be lazyloaded automatically via [lazySizes](https://github.com/aFarkas/lazysizes), but requires lazysizes to be loaded separately.
 - The `<Img />` component can also take any prop that an HTML5 img can take.
 
 
@@ -16,7 +16,6 @@ If you use these params, be sure to include either a `src` or and `imgixSrc`
 <Img
   mobileSrc='https://learnedia.com/wp-content/uploads/2017/02/cute-dog.jpg'
   tabletSrc='https://learnedia.com/wp-content/uploads/2017/02/puppy.jpg'
-  desktopImgixSrc='placeholders/stocksy-medium-2.jpg'
   imgixSrc='placeholders/stocksy-medium-2.jpg'
 />
 ```

--- a/src/atoms/Img/__tests__/__snapshots__/img.spec.js.snap
+++ b/src/atoms/Img/__tests__/__snapshots__/img.spec.js.snap
@@ -3,15 +3,15 @@
 exports[`<Img /> renders correctly with default props 1`] = `
 <img
   alt="alexander dummer 150646"
-  className="img lazyload"
-  data-sizes="auto"
+  className="img"
+  data-sizes="100vw"
   data-src="https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
   data-srcset="
   https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?fit=max&auto=format&ch=Width,DPR&w={width}&dpr=1 1x,
   https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?fit=max&auto=format&ch=Width,DPR&w={width}&dpr=2 2x,
   https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?fit=max&auto=format&ch=Width,DPR&w={width}&dpr=3 3x,
 "
-  src={undefined}
+  src="https://policygenius-images.imgix.net/photos/alexander-dummer-150646.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
   title="alexander dummer 150646"
 />
 `;
@@ -30,11 +30,11 @@ exports[`<Img /> renders correctly with given imgix picture source props 1`] = `
   />
   <img
     alt="default"
-    className="img lazyload"
+    className="img"
     data-sizes="auto"
     data-src="https://policygenius-images.imgix.net/default.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
     desktopImgixSrc="large"
-    src={undefined}
+    src="https://policygenius-images.imgix.net/default.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
     title="default"
   />
 </picture>
@@ -43,8 +43,8 @@ exports[`<Img /> renders correctly with given imgix picture source props 1`] = `
 exports[`<Img /> renders correctly with given imgix props 1`] = `
 <img
   alt="are cool"
-  className="img lazyload cool-class"
-  data-sizes="auto"
+  className="img cool-class"
+  data-sizes="100vw"
   data-src="https://policygenius-images.imgix.net/photos/are-cool.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
   data-srcset="
   https://policygenius-images.imgix.net/photos/are-cool.jpg?fit=max&auto=format&ch=Width,DPR&w={width}&dpr=1 1x,
@@ -53,7 +53,7 @@ exports[`<Img /> renders correctly with given imgix props 1`] = `
 "
   maxHeight="20"
   maxWidth="10"
-  src={undefined}
+  src="https://policygenius-images.imgix.net/photos/are-cool.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
   title="are cool"
 />
 `;
@@ -72,11 +72,11 @@ exports[`<Img /> renders correctly with given regular picture source props 1`] =
   />
   <img
     alt="Alternative"
-    className="img lazyload"
+    className="img"
     data-sizes="auto"
     data-src="default.jpg"
     desktopSrc="large"
-    src={undefined}
+    src="default.jpg"
     title="Alternative"
   />
 </picture>
@@ -85,13 +85,13 @@ exports[`<Img /> renders correctly with given regular picture source props 1`] =
 exports[`<Img /> renders correctly with given regular props 1`] = `
 <img
   alt="alt"
-  className="img lazyload cool-class"
-  data-sizes="auto"
+  className="img cool-class"
+  data-sizes="100vw"
   data-src="some-url"
   data-srcset="some-url"
   maxHeight="20"
   maxWidth="10"
-  src={undefined}
+  src="some-url"
   title="title"
 />
 `;
@@ -102,10 +102,10 @@ exports[`<Img /> renders with hide classes when null src props are provided 1`] 
 >
   <img
     alt="default"
-    className="img lazyload"
+    className="img"
     data-sizes="auto"
     data-src="https://policygenius-images.imgix.net/default.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
-    src={undefined}
+    src="https://policygenius-images.imgix.net/default.jpg?fit=max&auto=format&ch=Width,DPR&w={width}"
     title="default"
   />
 </picture>

--- a/src/atoms/Img/img.module.scss
+++ b/src/atoms/Img/img.module.scss
@@ -33,10 +33,6 @@
     display: block;
   }
 
-  .unlazy {
-    opacity: 1;
-  }
-
   .lazyloaded {
     opacity: 1;
     width: 100%;

--- a/src/atoms/Img/index.js
+++ b/src/atoms/Img/index.js
@@ -3,18 +3,19 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './img.module.scss';
 
-if (typeof window !== 'undefined') {
-  window.lazySizesConfig = window.lazySizesConfig || {};
-  window.lazySizesConfig.preloadAfterLoad = true;
+const checkLS = () => {
+  if (typeof window !== 'undefined' && !window.lazySizes) {
+    /* eslint-disable no-console */
+    console.warn('lazysizes not loaded.');
+    /* eslint-enable no-console */
 
-  require('lazysizes/plugins/rias/ls.rias.min');
-  require('lazysizes/lazysizes.min');
-}
+    return false;
+  }
 
+  return true;
+};
 const strParams = '?fit=max&auto=format&ch=Width,DPR&w={width}';
-
 const imgixSrcStr = src => `https://policygenius-images.imgix.net/${src}${strParams}`;
-
 const imgixSrcset = src => `
   https://policygenius-images.imgix.net/${src}${strParams}&dpr=1 1x,
   https://policygenius-images.imgix.net/${src}${strParams}&dpr=2 2x,
@@ -47,6 +48,8 @@ function Img(props) {
     ...rest
   } = props;
 
+  const isLazy = lazy && checkLS();
+
   const isPicture = mobileSrc !== undefined ||
     tabletSrc !== undefined ||
     mobileImgixSrc !== undefined ||
@@ -54,8 +57,7 @@ function Img(props) {
 
   const classes = cx(
     styles['img'],
-    'lazyload',
-    !lazy && 'unlazy',
+    isLazy && 'lazyload',
     className,
   );
 
@@ -82,12 +84,12 @@ function Img(props) {
         { ( mobileImgixSrc || mobileSrc ) && <source srcSet={mobileSrc || imgixSrcStr(mobileImgixSrc)} media='(max-width: 767px)' />}
         { ( tabletImgixSrc || tabletSrc ) && <source srcSet={tabletSrc || imgixSrcStr(tabletImgixSrc)} media='(max-width: 1024px)' />}
         <img
-          className={cx(styles.img, 'lazyload')}
+          className={cx(styles.img, isLazy && 'lazyload')}
           alt={alt || createName(src || imgixSrc)}
           title={title || alt || createName(src || imgixSrc)}
           data-src={defaultSrc}
           data-sizes='auto'
-          src={lazy ? undefined : defaultSrc}
+          src={isLazy ? undefined : defaultSrc}
           {...rest}
         />
       </picture>
@@ -101,13 +103,12 @@ function Img(props) {
       title={title || alt || createName(src || imgixSrc)}
       data-src={src || imgixSrcStr(imgixSrc)}
       data-srcset={srcset}
-      data-sizes={lazy ? 'auto' : '100vw'}
-      src={lazy ? undefined : src || imgixSrcStr(imgixSrc)}
+      data-sizes={isLazy ? 'auto' : '100vw'}
+      src={isLazy ? undefined : src || imgixSrcStr(imgixSrc)}
       {...rest}
     />
   );
 }
-
 
 Img.propTypes = {
   /**

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -23,6 +23,8 @@ module.exports = {
   webpackConfig,
   serverPort: parseInt(process.env.PORT, 10) || 6060,
   require: [
+    'lazysizes/plugins/rias/ls.rias.min',
+    'lazysizes/lazysizes.min',
     'holderjs',
     'assets/stylesheets/base.scss',
     path.join(__dirname, 'styleguide_assets/rcl_styles.module.scss')

--- a/styleguide_assets/index.html
+++ b/styleguide_assets/index.html
@@ -33,5 +33,9 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      window.lazySizesConfig = window.lazySizesConfig || {};
+      window.lazySizesConfig.preloadAfterLoad = true;
+    </script>
   </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,7 +2997,7 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -5646,7 +5646,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -7123,10 +7123,6 @@ lodash._baseget@^3.0.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/lodash._baseget/-/lodash._baseget-3.7.2.tgz#1b6ae1d5facf3c25532350a13c1197cb8bb674f4"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -7142,13 +7138,9 @@ lodash._basevalues@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -7158,17 +7150,11 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -7354,7 +7340,7 @@ lodash.reject@4.6.0, lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -10355,7 +10341,7 @@ readable-stream@~2.0.0:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -12981,7 +12967,7 @@ vali-date@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
We should let the consumer choose to use lazysizes and not automatically
bundle it. Now, our pg-gatsby repo is handling this itself.
  
https://app.clubhouse.io/policygenius/story/15151/implement-contentful-img-component