### PR TITLE
Update react peer dependency and yarn engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "peerDependencies": {
-    "react": "^16.2.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "engines": {
     "yarn": "^1.3.2",


### PR DESCRIPTION
@drewdrewthis @samanthavholmes CR please

This updates the React `peerDependency` to include both versions 15 and 16 as well as allowing to use a yarn engine lower than `1.0.0`.