### PR TITLE
Add GrayBox to Layout

### DIFF
--- a/src/atoms/GrayBox/Readme.md
+++ b/src/atoms/GrayBox/Readme.md
@@ -1,0 +1,24 @@
+This `GrayBox` is a gray container for content. See `BlockHeader` for an example.
+
+## GrayBox Example 
+```jsx
+  <GrayBox
+    cols={8}
+    variant='right'
+    colorDash='primary-3'
+    leftOffset={3}
+    colorDashPosition='right'
+  >
+    <div>
+      <Text variant='label'>
+        I'm a super title
+      </Text>
+      <Text tag='h2' font='a' size={2}>
+        A box. A gray box.
+      </Text>
+      <Text font='b' size={9}>
+        2018. The Year of The Color Dash
+      </Text>
+    </div>
+  </GrayBox>;
+```

--- a/src/atoms/GrayBox/index.js
+++ b/src/atoms/GrayBox/index.js
@@ -26,7 +26,7 @@ const GrayBox = ({
     variant && styles[variant],
     colorDash && colors[`color-dash-${colorDash}`],
     leftOffset && styles[`offset-${leftOffset}`],
-    (colorDashPosition === 'left' ? styles['left-dash'] : styles['right-dash']),
+    colorDashPosition === 'left' ? styles['left-dash'] : styles['right-dash'],
     className
   );
 
@@ -78,7 +78,7 @@ GrayBox.propTypes = {
   children: PropTypes.node,
   verticalPadding: PropTypes.string,
   leftOffset: PropTypes.number,
-  colorDashPosition: PropTypes.oneOf(['left', 'right']),
+  colorDashPosition: PropTypes.oneOf([ 'left', 'right' ]),
 };
 
 export default GrayBox;

--- a/src/atoms/Layout/Col/index.js
+++ b/src/atoms/Layout/Col/index.js
@@ -19,7 +19,8 @@ function Col(props) {
     style,
     bottomSpacing,
     onClick,
-    borderColor
+    borderColor,
+    offset,
   } = props;
 
   const classes = [
@@ -34,6 +35,7 @@ function Col(props) {
     bottomSpacing && styles[`bottom-spacing-${bottomSpacing}`],
     padding && styles['padding'],
     colors[`border-${borderColor}`],
+    offset && styles[`col-offset-${offset}`],
     className
   ];
 
@@ -128,7 +130,11 @@ Col.propTypes = {
    * Sets the border color for the Col. To see a border, give the border a width and a style directly.
    * Can only be one of the named brand colors.
    */
-  borderColor: PropTypes.string
+  borderColor: PropTypes.string,
+  /**
+   * The number of columns to shift Col from the left
+   */
+  offset: PropTypes.number,
 };
 
 Col.defaultProps = {

--- a/src/atoms/Layout/GreyBox/Readme.md
+++ b/src/atoms/Layout/GreyBox/Readme.md
@@ -1,0 +1,2 @@
+The `GreyBox` component is a variation of the `Column` component. See `Column` component for usage details.
+This `GreyBox` serves as a gray background to a `Layout` and is intended to only be used within a `Layout`.

--- a/src/atoms/Layout/GreyBox/index.js
+++ b/src/atoms/Layout/GreyBox/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import styles from '../layout.module.scss';
+import Col from '../Col';
+
+function GreyBox(props) {
+  const {
+    className,
+  } = props;
+
+  const classes = cx(
+    styles['grey-box'],
+    className,
+  );
+
+  return (
+    <Col
+      {...props}
+      className={classes}
+    />
+  );
+}
+
+GreyBox.rclName = 'Col';
+
+GreyBox.propTypes = {
+  /**
+   * Supply any additional class names.
+   */
+  className: PropTypes.string,
+};
+
+export default GreyBox;

--- a/src/atoms/Layout/Readme.md
+++ b/src/atoms/Layout/Readme.md
@@ -90,6 +90,90 @@ All child component props will be passed directly to the component itself.
     </div>
 ```
 
+## Layout with GreyBox background Example:
+
+
+```jsx
+    <div>
+      <Layout
+        smallCols={[ 6 ]}
+        mediumCols={[ 8, 2 ]}
+        style={{ position: 'relative' }}
+      >
+        <GreyBox
+          offset={2}
+          style={{ zIndex: 1 }}
+        />
+        <Col
+          offset={5}
+          style={{ zIndex: 1 }}
+        >
+          <Text variant='label'>
+            supertitle
+          </Text>
+          <Text tag='h2' font='a' size={2}>
+            title
+          </Text>
+          <Text font='b' size={9}>
+            description
+          </Text>
+        </Col>
+      </Layout>
+    </div>
+```
+
+## Layout with GreyBox background Example 2:
+
+
+```jsx
+    <div>
+      <Layout
+        smallCols={[ 6 ]}
+        mediumCols={[ 3 ]}
+        style={{ position: 'relative' }}
+      >
+        <GreyBox
+          offset={2}
+          mediumCols={9}
+          style={{ zIndex: 1 }}
+        />
+        <Col
+          offset={1}
+          style={{ zIndex: 1 }}
+        >
+          <CompanyCard
+            starRating={5}
+            imageAttr={{
+              src: 'https://policygenius-images.imgix.net/photos/life/lincoln-financial-black-logo.svg?fit=max&auto=format&ch=Width,DPR&w={width}'
+            }}
+            variant='small'
+          />
+        </Col>
+        <Col
+          style={{ zIndex: 1 }}
+        >
+          <CompanyCard
+            starRating={5}
+            imageAttr={{
+              src: 'https://policygenius-images.imgix.net/photos/life/lincoln-financial-black-logo.svg?fit=max&auto=format&ch=Width,DPR&w={width}'
+            }}
+            variant='small'
+          />
+        </Col>
+        <Col
+          style={{ zIndex: 1 }}
+        >
+          <CompanyCard
+            starRating={5}
+            imageAttr={{
+              src: 'https://policygenius-images.imgix.net/photos/life/lincoln-financial-black-logo.svg?fit=max&auto=format&ch=Width,DPR&w={width}'
+            }}
+            variant='small'
+          />
+        </Col>
+      </Layout>
+    </div>
+```
 ## Nested Grid Example:
 
 ```jsx

--- a/src/atoms/Layout/index.js
+++ b/src/atoms/Layout/index.js
@@ -163,3 +163,4 @@ Layout.defaultProps = {
 };
 
 export { Layout as default, Layout, Col };
+export { GreyBox } from './GreyBox';

--- a/src/atoms/Layout/layout.module.scss
+++ b/src/atoms/Layout/layout.module.scss
@@ -6,6 +6,18 @@ $spacer-base: .25;
     .col-#{$size}-#{$i} {
       @include g-unit($i);
     }
+
+    @media #{$small-only} {
+      .col-offset-#{$i} {
+        margin-left: 0;
+      }
+    }
+
+    @media #{$medium-up} {
+      .col-offset-#{$i} {
+        margin-left: calc((100% / 12) * #{$i});
+      }
+    }
   }
 
   .col-#{$size}-auto {
@@ -148,4 +160,13 @@ $spacer-base: .25;
 .nested {
   margin-left: -$gutter-width;
   margin-right: -$gutter-width;
+}
+
+.grey-box {
+  position: absolute;
+  width: 100%;
+  height: calc(100% + 72px);
+  top: -36px;
+  background-color: color('neutral-5');
+  z-index: -1;
 }

--- a/src/atoms/Layout/utils.js
+++ b/src/atoms/Layout/utils.js
@@ -99,4 +99,3 @@ export function processChildren(props) {
     return processChild(child, layoutProps);
   });
 }
-


### PR DESCRIPTION
The current GrayBox component works great for it's intended purpose:
being a gray box that holds some content. However, sometimes we need a
gray box that is merely a background and doesn't care if there is
content inside. LayoutGrayBox is that. When placed inside a layout it
serves as a background to that layout and doesn't affect the other
columns within that layout