### PR TITLE
Fix Tooltip Bug - Not Closing Modal on Mobile

### DIFF
--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -42,31 +42,33 @@ class Tooltip extends React.Component {
     } = this.props;
 
     return (
-      <span
-        onClick={onClick || this.openModal}
-        className={classnames(
-          styles['tooltip-wrapper'],
-          inline && styles[`inline-${inline}`],
-          className
-        )}
-      >
-        {
-          text ||
-            <Icon
-              icon='tooltip'
-              className={styles['tooltip']}
-              inline={inline}
-            />
-        }
+      <span>
         <span
+          onClick={onClick || this.openModal}
           className={classnames(
-            children && styles['hover-message'],
-            left && styles['left'],
-            right && styles['right'],
-            hoverMessageClassName
+            styles['tooltip-wrapper'],
+            inline && styles[`inline-${inline}`],
+            className
           )}
         >
-          { children }
+          {
+            text ||
+              <Icon
+                icon='tooltip'
+                className={styles['tooltip']}
+                inline={inline}
+              />
+          }
+          <span
+            className={classnames(
+              children && styles['hover-message'],
+              left && styles['left'],
+              right && styles['right'],
+              hoverMessageClassName
+            )}
+          >
+            { children }
+          </span>
         </span>
         <Modal
           header='Learn more'
@@ -77,6 +79,7 @@ class Tooltip extends React.Component {
           {children}
         </Modal>
       </span>
+
     );
   }
 }

--- a/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
+++ b/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
@@ -16,14 +16,16 @@ exports[`<RadioGroup /> renders correctly 1`] = `
         <span>
           Test label
         </span>
-        <span
-          className="tooltip-wrapper tooltip"
-          onClick={[Function]}
-        >
+        <span>
           <span
-            className="hover-message right"
+            className="tooltip-wrapper tooltip"
+            onClick={[Function]}
           >
-            Hello friend
+            <span
+              className="hover-message right"
+            >
+              Hello friend
+            </span>
           </span>
         </span>
       </div>

--- a/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
+++ b/src/organisms/cards/FeaturedPolicyCard/__tests__/__snapshots__/featured_policy_card.spec.js.snap
@@ -69,19 +69,21 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
             onClick={undefined}
             style={undefined}
           >
-            <span
-              className="tooltip-wrapper policy-info-tooltip-icon"
-              onClick={[Function]}
-            >
+            <span>
               <span
-                className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                className="tooltip-wrapper policy-info-tooltip-icon"
+                onClick={[Function]}
               >
-                Financial Strength
-              </span>
-              <span
-                className="hover-message"
-              >
-                <div />
+                <span
+                  className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                >
+                  Financial Strength
+                </span>
+                <span
+                  className="hover-message"
+                >
+                  <div />
+                </span>
               </span>
             </span>
           </div>
@@ -114,19 +116,21 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
             onClick={undefined}
             style={undefined}
           >
-            <span
-              className="tooltip-wrapper policy-info-tooltip-icon"
-              onClick={[Function]}
-            >
+            <span>
               <span
-                className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                className="tooltip-wrapper policy-info-tooltip-icon"
+                onClick={[Function]}
               >
-                Total Customers
-              </span>
-              <span
-                className="hover-message"
-              >
-                <div />
+                <span
+                  className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                >
+                  Total Customers
+                </span>
+                <span
+                  className="hover-message"
+                >
+                  <div />
+                </span>
               </span>
             </span>
           </div>
@@ -159,19 +163,21 @@ exports[`<FeaturedPolicyCard /> renders correctly 1`] = `
             onClick={undefined}
             style={undefined}
           >
-            <span
-              className="tooltip-wrapper policy-info-tooltip-icon"
-              onClick={[Function]}
-            >
+            <span>
               <span
-                className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                className="tooltip-wrapper policy-info-tooltip-icon"
+                onClick={[Function]}
               >
-                Policy Type
-              </span>
-              <span
-                className="hover-message"
-              >
-                <div />
+                <span
+                  className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                >
+                  Policy Type
+                </span>
+                <span
+                  className="hover-message"
+                >
+                  <div />
+                </span>
               </span>
             </span>
           </div>

--- a/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
+++ b/src/organisms/cards/PolicyCard/__tests__/__snapshots__/policy_card.spec.js.snap
@@ -72,19 +72,21 @@ exports[`<PolicyCard /> renders correctly 1`] = `
                 onClick={undefined}
                 style={undefined}
               >
-                <span
-                  className="tooltip-wrapper policy-info-tooltip-icon"
-                  onClick={[Function]}
-                >
+                <span>
                   <span
-                    className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                    className="tooltip-wrapper policy-info-tooltip-icon"
+                    onClick={[Function]}
                   >
-                    label
-                  </span>
-                  <span
-                    className="hover-message"
-                  >
-                    <div />
+                    <span
+                      className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                    >
+                      label
+                    </span>
+                    <span
+                      className="hover-message"
+                    >
+                      <div />
+                    </span>
                   </span>
                 </span>
               </div>
@@ -117,19 +119,21 @@ exports[`<PolicyCard /> renders correctly 1`] = `
                 onClick={undefined}
                 style={undefined}
               >
-                <span
-                  className="tooltip-wrapper policy-info-tooltip-icon"
-                  onClick={[Function]}
-                >
+                <span>
                   <span
-                    className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                    className="tooltip-wrapper policy-info-tooltip-icon"
+                    onClick={[Function]}
                   >
-                    label
-                  </span>
-                  <span
-                    className="hover-message"
-                  >
-                    <div />
+                    <span
+                      className="primary-3 policy-info-tooltip-label type-b-10-medium inherit"
+                    >
+                      label
+                    </span>
+                    <span
+                      className="hover-message"
+                    >
+                      <div />
+                    </span>
                   </span>
                 </span>
               </div>
@@ -244,35 +248,37 @@ exports[`<PolicyCard /> renders correctly 1`] = `
       <div
         className="policy-type"
       >
-        <span
-          className="tooltip-wrapper policy-type-tooltip"
-          onClick={[Function]}
-        >
-          <div>
-            <div
-              className="hide mobile"
-            >
-              <p
-                className="neutral-2 spaced type-a-11-bold inherit"
+        <span>
+          <span
+            className="tooltip-wrapper policy-type-tooltip"
+            onClick={[Function]}
+          >
+            <div>
+              <div
+                className="hide mobile"
               >
-                LABEL
-              </p>
+                <p
+                  className="neutral-2 spaced type-a-11-bold inherit"
+                >
+                  LABEL
+                </p>
+              </div>
+              <strong
+                className="primary-3 policy-name type-a-7-bold inherit"
+              >
+                Some policy
+              </strong>
+              <strong
+                className="bold neutral-2 policy-tooltip type-b-7-medium inherit"
+              >
+                <div />
+              </strong>
             </div>
-            <strong
-              className="primary-3 policy-name type-a-7-bold inherit"
-            >
-              Some policy
-            </strong>
-            <strong
-              className="bold neutral-2 policy-tooltip type-b-7-medium inherit"
+            <span
+              className="hover-message policy-type-hover-message"
             >
               <div />
-            </strong>
-          </div>
-          <span
-            className="hover-message policy-type-hover-message"
-          >
-            <div />
+            </span>
           </span>
         </span>
       </div>
@@ -282,136 +288,142 @@ exports[`<PolicyCard /> renders correctly 1`] = `
       <div
         className="hide policy-info mobile tablet"
       >
-        <span
-          className="tooltip-wrapper policy-info-tooltip"
-          onClick={[Function]}
-        >
-          <p
-            className="neutral-2 spaced type-a-11-bold inherit"
+        <span>
+          <span
+            className="tooltip-wrapper policy-info-tooltip"
+            onClick={[Function]}
           >
-            <div
-              className="layout"
-              id={undefined}
-              style={undefined}
+            <p
+              className="neutral-2 spaced type-a-11-bold inherit"
             >
               <div
-                className="col col-sm-7 fullwidth border-neutral-6"
+                className="layout"
                 id={undefined}
-                onClick={undefined}
                 style={undefined}
               >
                 <div
-                  className="policy-info-label"
+                  className="col col-sm-7 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
                 >
-                  LABEL
+                  <div
+                    className="policy-info-label"
+                  >
+                    LABEL
+                  </div>
+                </div>
+                <div
+                  className="col col-sm-5 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
+                >
+                  <strong
+                    className="primary-3 type-a-8-bold inherit"
+                  >
+                    A+
+                  </strong>
                 </div>
               </div>
-              <div
-                className="col col-sm-5 fullwidth border-neutral-6"
-                id={undefined}
-                onClick={undefined}
-                style={undefined}
-              >
-                <strong
-                  className="primary-3 type-a-8-bold inherit"
-                >
-                  A+
-                </strong>
-              </div>
-            </div>
-          </p>
-          <span
-            className="hover-message policy-type-hover-message"
-          >
-            <div />
+            </p>
+            <span
+              className="hover-message policy-type-hover-message"
+            >
+              <div />
+            </span>
           </span>
         </span>
-        <span
-          className="tooltip-wrapper policy-info-tooltip"
-          onClick={[Function]}
-        >
-          <p
-            className="neutral-2 spaced type-a-11-bold inherit"
+        <span>
+          <span
+            className="tooltip-wrapper policy-info-tooltip"
+            onClick={[Function]}
           >
-            <div
-              className="layout"
-              id={undefined}
-              style={undefined}
+            <p
+              className="neutral-2 spaced type-a-11-bold inherit"
             >
               <div
-                className="col col-sm-7 fullwidth border-neutral-6"
+                className="layout"
                 id={undefined}
-                onClick={undefined}
                 style={undefined}
               >
                 <div
-                  className="policy-info-label"
+                  className="col col-sm-7 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
                 >
-                  LABEL
+                  <div
+                    className="policy-info-label"
+                  >
+                    LABEL
+                  </div>
+                </div>
+                <div
+                  className="col col-sm-5 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
+                >
+                  <strong
+                    className="primary-3 type-a-8-bold inherit"
+                  >
+                    A+
+                  </strong>
                 </div>
               </div>
-              <div
-                className="col col-sm-5 fullwidth border-neutral-6"
-                id={undefined}
-                onClick={undefined}
-                style={undefined}
-              >
-                <strong
-                  className="primary-3 type-a-8-bold inherit"
-                >
-                  A+
-                </strong>
-              </div>
-            </div>
-          </p>
-          <span
-            className="hover-message policy-type-hover-message"
-          >
-            <div />
+            </p>
+            <span
+              className="hover-message policy-type-hover-message"
+            >
+              <div />
+            </span>
           </span>
         </span>
-        <span
-          className="tooltip-wrapper policy-info-tooltip"
-          onClick={[Function]}
-        >
-          <p
-            className="neutral-2 spaced type-a-11-bold inherit"
+        <span>
+          <span
+            className="tooltip-wrapper policy-info-tooltip"
+            onClick={[Function]}
           >
-            <div
-              className="layout"
-              id={undefined}
-              style={undefined}
+            <p
+              className="neutral-2 spaced type-a-11-bold inherit"
             >
               <div
-                className="col col-sm-7 fullwidth border-neutral-6"
+                className="layout"
                 id={undefined}
-                onClick={undefined}
                 style={undefined}
               >
                 <div
-                  className="policy-info-label"
+                  className="col col-sm-7 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
                 >
-                  LABEL
+                  <div
+                    className="policy-info-label"
+                  >
+                    LABEL
+                  </div>
+                </div>
+                <div
+                  className="col col-sm-5 fullwidth border-neutral-6"
+                  id={undefined}
+                  onClick={undefined}
+                  style={undefined}
+                >
+                  <strong
+                    className="primary-3 type-a-8-bold inherit"
+                  >
+                    16
+                  </strong>
                 </div>
               </div>
-              <div
-                className="col col-sm-5 fullwidth border-neutral-6"
-                id={undefined}
-                onClick={undefined}
-                style={undefined}
-              >
-                <strong
-                  className="primary-3 type-a-8-bold inherit"
-                >
-                  16
-                </strong>
-              </div>
-            </div>
-          </p>
-          <span
-            className="hover-message policy-type-hover-message"
-          >
-            <div />
+            </p>
+            <span
+              className="hover-message policy-type-hover-message"
+            >
+              <div />
+            </span>
           </span>
         </span>
       </div>

--- a/src/utils/fieldUtils/__tests__/renderTooltip.spec.js
+++ b/src/utils/fieldUtils/__tests__/renderTooltip.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import Icon from 'atoms/Icon';
 import Modal from 'molecules/Modal';
@@ -19,11 +19,13 @@ describe('renderTooltip()', () => {
         const tooltip = 'Hello world';
 
         const component = renderTooltip(tooltip, className, iconClassName);
-        const wrapper = shallow(component);
+        const wrapper = mount(component);
+        const tooltipElement = wrapper.children().childAt(0);
+        const modalElement = wrapper.children().childAt(1);
 
-        expect(wrapper.props().className).toContain(className);
-        expect(wrapper.props().children.filter(child => child.props.children === tooltip && child.type !== Modal).length).toEqual(1);
-        expect(wrapper.props().children.filter(child => child.props.children === tooltip && child.type === Modal).length).toEqual(1);
+        expect(tooltipElement.props().className).toContain(className);
+        expect(tooltipElement.props().children.filter(child => child.props.children === tooltip && child.type !== Modal).length).toEqual(1);
+        expect(modalElement.length).toEqual(1);
       });
     });
 
@@ -32,9 +34,10 @@ describe('renderTooltip()', () => {
         const tooltip = jest.fn();
 
         const component = renderTooltip(tooltip, className, iconClassName);
-        const wrapper = shallow(component);
+        const wrapper = mount(component);
+        const tooltipElement = wrapper.children().childAt(0);
 
-        expect(wrapper.props().onClick).toEqual(tooltip);
+        expect(tooltipElement.props().onClick).toEqual(tooltip);
       });
     });
   });
@@ -44,12 +47,12 @@ describe('renderTooltip()', () => {
       const tooltip = 'Hello world';
 
       const component = renderTooltip(tooltip, className, iconClassName);
-      const wrapper = shallow(component);
+      const wrapper = mount(component);
 
-      const icon = wrapper.props().children.find(child => child.type === Icon);
+      const icon = wrapper.findWhere(n => n.type() === Icon);
 
-      expect(icon.props.icon).toEqual('tooltip');
-      expect(icon.props.className).toContain(iconClassName);
+      expect(icon.props().icon).toEqual('tooltip');
+      expect(icon.props().className).toContain(iconClassName);
     });
   });
 });


### PR DESCRIPTION
When you clicked the Tooltip on mobile and a modal popped up, users were
not able to close that modal. The Tooltips openModal function was firing
everytime a user clicked the X on the modal. This was because the modal
was nested inside a `<span>` with an onClick handler.

The solution was to move make the Modal a sibling of the Tooltip instead
of a child.