### PR TITLE
Update GrayBox component position

### DIFF
--- a/src/molecules/BlockHeader/GrayBox/gray-box.module.scss
+++ b/src/molecules/BlockHeader/GrayBox/gray-box.module.scss
@@ -59,8 +59,8 @@
       }
 
       &:before {
-        padding-right: #{$section-padding-desktop};
-        right: -#{$section-padding-desktop};
+        padding-right: #{$section-padding-desktop + $gutter-width};
+        right: -#{$section-padding-desktop + $gutter-width};
       }
     }
 
@@ -71,8 +71,8 @@
       }
 
       &:before {
-        left: -#{$section-padding-desktop};
-        padding-left: #{$section-padding-desktop};
+        left: -#{$section-padding-desktop + $gutter-width};
+        padding-left: #{$section-padding-desktop + $gutter-width};
       }
     }
   }


### PR DESCRIPTION
The amount we need to shift the `GrayBox`, left or right, depends on the
section padding. However section padding doesn't take into account the
12px gutter from `Layout`. So we have to add the 12px back