### PR TITLE
Add Google autocomplete field

### DIFF
--- a/src/molecules/formfields/GoogleAutoCompleteField/Readme.md
+++ b/src/molecules/formfields/GoogleAutoCompleteField/Readme.md
@@ -1,0 +1,12 @@
+GoogleAutoCompleteField Example:
+
+**You must provide either a `googlePlacesLink` or `googlePlacesAPIKey` prop for this example to work**
+
+```jsx
+  <GoogleAutoCompleteField
+    input={{
+      name: 'street',
+    }}
+    autocompleteAddressFields={(data) => { alert(JSON.stringify(data)) }}
+  />
+```

--- a/src/molecules/formfields/GoogleAutoCompleteField/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/molecules/formfields/GoogleAutoCompleteField/__tests__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<GoogleAutoCompleteField /> renders correctly 1`] = `
+<div>
+  <div
+    className="text-field"
+  >
+    <div
+      className="header"
+    >
+      <div
+        className="label-wrapper"
+      >
+        <label
+          className="label"
+          htmlFor={undefined}
+        >
+          Street address
+        </label>
+      </div>
+    </div>
+    <span
+      className="input-wrapper"
+      data-postfix={undefined}
+      data-prefix={undefined}
+    >
+      <input
+        className="input"
+        id="autocomplete"
+        name="streetAddress"
+        placeholder="Enter your street address"
+        type="text"
+        value={undefined}
+      />
+    </span>
+  </div>
+  <span />
+</div>
+`;

--- a/src/molecules/formfields/GoogleAutoCompleteField/__tests__/index.spec.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/__tests__/index.spec.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
+import TextField from 'molecules/formfields/TextField';
+
+import GoogleAutoCompleteField from '../';
+
+describe('<GoogleAutoCompleteField />', () => {
+  let props;
+  let addressValues;
+
+  beforeEach(() => {
+    props = {
+      input: {
+        name: 'streetAddress',
+      },
+      label: 'Street address',
+      placeholder: 'Enter your street address',
+      autocompleteAddressFields: jest.fn(),
+    };
+
+    addressValues = [
+      {
+        types: [
+          'street_number'
+        ],
+        short_name: '1',
+        long_name: '1',
+      },
+      {
+        types: [
+          'route'
+        ],
+        long_name: 'Broadway',
+        short_name: 'Broadway',
+      },
+      {
+        types: [
+          'sublocality_level_1'
+        ],
+        long_name: 'New York',
+        short_name: 'New York',
+      },
+      {
+        types: [
+          'administrative_area_level_1'
+        ],
+        short_name: 'NY',
+        long_name: 'New York',
+      },
+      {
+        types: [
+          'postal_code'
+        ],
+        short_name: '10075',
+        long_name: '10075',
+      },
+    ];
+  });
+
+  it('renders correctly', () => {
+    const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
+
+    const actual = renderer.create(wrapper).toJSON();
+
+    expect(actual).toMatchSnapshot();
+  });
+
+  it('returns a single TextField with appropriate props', () => {
+    const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
+
+    const field = wrapper.find(TextField);
+
+    expect(field.length).toEqual(1);
+    expect(field.props().name).toEqual(props.name);
+    expect(field.props().label).toEqual('Street address');
+    expect(field.props().placeholder).toEqual('Enter your street address');
+    expect(field.props().id).toEqual('autocomplete');
+  });
+
+  describe('updateAddress', () => {
+    it('calls autocomplete.getPlace and props.autocompleteAddressFields', () => {
+      const expectedData = {
+        number: '1',
+        street: 'Broadway',
+        city: 'New York',
+        state: 'New York',
+        zip: '10075',
+      };
+
+      const state = {
+        autocomplete: {
+          getPlace: jest.fn(() => {
+            return {
+              address_components: addressValues,
+            };
+          })
+        }
+      };
+
+      const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
+
+      wrapper.setState(state);
+
+      wrapper.instance().updateAddress();
+
+      expect(state.autocomplete.getPlace.mock.calls.length).toBe(1);
+      expect(props.autocompleteAddressFields.mock.calls.length).toBe(1);
+      expect(props.autocompleteAddressFields.mock.calls[0][0]).toEqual(expectedData);
+    });
+  });
+
+  describe('formatAddressInfo', () => {
+    it('returns the correctly formatted data', () => {
+      const expectedData = {
+        number: {
+          shortName: '1',
+          longName: '1',
+        },
+        street: {
+          shortName: 'Broadway',
+          longName: 'Broadway',
+        },
+        city: {
+          shortName: 'New York',
+          longName: 'New York',
+        },
+        state: {
+          shortName: 'NY',
+          longName: 'New York',
+        },
+        zip: {
+          shortName: '10075',
+          longName: '10075',
+        },
+      };
+
+      const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
+
+      expect(wrapper.instance().formatAddressInfo(addressValues)).toEqual(expectedData);
+    });
+  });
+
+  describe('pickData', () => {
+    it('returns the correctly picked data', () => {
+      const expectedData = {
+        number: '1',
+        street: 'Broadway',
+        city: 'New York',
+        state: 'New York',
+        zip: '10075',
+      };
+
+      const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
+
+      const data = wrapper.instance().formatAddressInfo(addressValues);
+
+      expect(wrapper.instance().pickData(data)).toEqual(expectedData);
+    });
+  });
+});

--- a/src/molecules/formfields/GoogleAutoCompleteField/constants.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/constants.js
@@ -1,0 +1,11 @@
+export const GOOGLE_ADDRESS_VALUES_MAP = {
+  street_number: 'number',
+  route: 'street',
+  locality: 'city',
+  sublocality_level_1: 'city',
+  neighborhood: 'neighborhood',
+  administrative_area_level_1: 'state',
+  administrative_area_level_2: 'county',
+  country: 'country',
+  postal_code: 'zip'
+};

--- a/src/molecules/formfields/GoogleAutoCompleteField/index.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/index.js
@@ -1,0 +1,188 @@
+/* eslint-disable no-undef */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import pick from 'lodash/pick';
+import reduce from 'lodash/reduce';
+import keys from 'lodash/keys';
+import TextField from 'molecules/formfields/TextField';
+
+import loadJS from './util/loadJS';
+import {
+  GOOGLE_ADDRESS_VALUES_MAP,
+} from './constants';
+
+class GoogleAutoCompleteField extends Component {
+  state = {
+    autocomplete: null,
+  }
+
+  componentDidMount() {
+    const {
+      googlePlacesLink,
+      googlePlacesAPIKey
+    } = this.props;
+
+    window.initMap = this.initMap;
+
+    if (googlePlacesLink || googlePlacesAPIKey) {
+      loadJS({
+        link: googlePlacesLink,
+        key: googlePlacesAPIKey,
+      });
+    }
+  }
+
+  initMap = () => {
+    const { id } = this.props;
+
+    const autocomplete = new google.maps.places.Autocomplete(
+      document.getElementById(`${id}`),
+      { types: [ 'geocode' ] }
+    );
+
+    this.setState({ autocomplete });
+
+    autocomplete.addListener('place_changed', () => {
+      this.updateAddress();
+    });
+  }
+
+  updateAddress = () => {
+    const place = this.state.autocomplete.getPlace();
+    const addressData = this.formatAddressInfo(place.address_components);
+    const data = this.pickData(addressData);
+
+    this.props.autocompleteAddressFields(data);
+  }
+
+  pickData = (addressData) => {
+    const { addressValuesToPick } = this.props;
+    const pickedData = pick(addressData, keys(addressValuesToPick));
+
+    // Grab the short or long name from the addressData based on props.addressValuesToPick
+    return reduce(pickedData, (res, names, addressValue) => Object.assign({}, res, {
+      [addressValue]: names[addressValuesToPick[addressValue]]
+    }), {});
+  }
+
+  formatAddressInfo(addressInfo) {
+    // Return an object where the laymen term value references both short_name and long_name
+    // Ex:
+    // info = {
+    //   short_name: 'Broadway',
+    //   long_name: 'Broadway,
+    //   types: ['route'],
+    // }
+    //
+    // becomes
+    //
+    // street: {
+    //  shortName: 'Broadway',
+    //  longName: 'Broadway,
+    // }
+
+    return addressInfo.reduce((res, info) => {
+      const addressType = info.types[0];
+      const formattedAddressValue = GOOGLE_ADDRESS_VALUES_MAP[addressType];
+
+      if (formattedAddressValue) {
+        return Object.assign({}, res, {
+          [formattedAddressValue]: {
+            shortName: info.short_name,
+            longName: info.long_name,
+          }
+        });
+      }
+
+      return res;
+    }, {});
+  }
+
+  render() {
+    const { id } = this.props;
+
+    return (
+      <TextField
+        {...this.props}
+        id={id}
+      />
+    );
+  }
+}
+
+GoogleAutoCompleteField.propTypes = {
+  /**
+   * Values to be passed down to the TextField rendered by this component.
+   * If using `redux-form`, this prop will come from the `Field` wrapper component.
+   * `name` is required in order to build the Google autocomplete data properly.
+   */
+  input: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+
+  /**
+   * Function that will be fired when a user selects an address from the autocomplete drop down.
+   * It will be passed a `data` object containing the values picked from the Google autocomplete response
+   */
+  autocompleteAddressFields: PropTypes.func.isRequired,
+
+  /**
+   * `id` prop onto which Google will hook the autocomplete functionality
+   */
+  id: PropTypes.string.isRequired,
+
+  /**
+   * A map of values to pick from the Google autocomplete response.
+   * Available values to pick are:
+   *
+   * ```
+   *  number
+   *  street
+   *  city
+   *  neighborhood
+   *  state
+   *  county
+   *  country
+   *  zip
+   * ```
+   *
+   * Available formatted values are: `shortName` and `longName`.
+   *
+   * You can construct this map as follows to receive the short name for number and long name for city:
+   *
+   * ```
+   * {
+      number: 'shortName',
+      city: 'longName',
+   * }
+   * ```
+   */
+  addressValuesToPick: PropTypes.object,
+
+  /**
+   * Google Places authorized API link.
+   * Providing this link will automatically load the necessary JS to enable the autocomplete functionality.
+   * It is recommended that you as the consumer handle loading the Google JS to prevent multiple loads if you use this component more than once.
+   */
+  googlePlacesLink: PropTypes.string,
+
+  /**
+   * Google Places authorized API Key.
+   * Providing this key will automatically load the necessary JS to enable the autocomplete functionality.
+   * It is recommended that you as the consumer handle loading the Google JS to prevent multiple loads if you use this component more than once.
+   */
+  googlePlacesAPIKey: PropTypes.string,
+};
+
+GoogleAutoCompleteField.defaultProps = {
+  id: 'autocomplete',
+  addressValuesToPick: {
+    number: 'shortName',
+    street: 'longName',
+    city: 'longName',
+    state: 'longName',
+    zip: 'shortName',
+  },
+};
+
+export default GoogleAutoCompleteField;

--- a/src/molecules/formfields/GoogleAutoCompleteField/util/loadJS.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/util/loadJS.js
@@ -1,0 +1,16 @@
+function buildSrc({ link, key }) {
+  if (link) return link;
+
+  return `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=places&callback=initMap`;
+}
+
+export default function loadJS({ link, key }) {
+  const src = buildSrc({ link, key });
+
+  const ref = window.document.getElementsByTagName('script')[0];
+  const script = window.document.createElement('script');
+
+  script.src = src;
+  script.async = true;
+  ref.parentNode.insertBefore(script, ref);
+}


### PR DESCRIPTION
@trevornelson @drewdrewthis @sunnymis CR please

[CH 16362](https://app.clubhouse.io/policygenius/story/16362/shoppers-should-be-able-to-use-google-maps-autocomplete-for-address)

Adds a `GoogleAutoCompleteField` to the RCL.

This field mimics the one already implemented in renters, but makes some optimizations to grab data from Google based on props and to conditionally include the Google Places API to make the field work. The reasoning for the latter is that the consumer should have the power over where/how the Google Places script gets loaded in to avoid multiple loads of the script/collisions.