### PR TITLE
Add new Modal variant for life widgets

### DIFF
--- a/src/molecules/Modal/Readme.md
+++ b/src/molecules/Modal/Readme.md
@@ -115,6 +115,104 @@ This uses [`ReactModal`](https://github.com/reactjs/react-modal) under the hood 
       this.setState({
         modalIsOpen: true
       });
+     }
+
+     closeModal() {
+        this.setState({
+          modalIsOpen: false
+        });
+      }
+
+      render() {
+        return (
+          <div>
+            <Button onClick={this.openModal}>Open No Header Modal</Button>
+
+            <Modal
+              variant='x-large'
+              onRequestClose={this.closeModal}
+              isOpen={this.state.modalIsOpen}
+              contentLabel='Modal'
+              hideHeader
+            >
+              <div>
+                <Layout
+                  mediumCols={[ 9, 3, 6, 3, 3 ]}
+                  bottomSpacing='small'
+                >
+                  <TextField
+                    label='Street address'
+                    placeholder='Enter your street address'
+                    input={{}}
+                  />
+                  <TextField
+                    label='Apt. #'
+                    placeholder='Apt. #'
+                    input={{}}
+                  />
+                  <TextField
+                    label='City'
+                    placeholder='City'
+                    input={{}}
+                  />
+                  <TextField
+                    label='State'
+                    placeholder='State'
+                    input={{}}
+                  />
+                  <TextField
+                    label='Zip code'
+                    placeholder='Zip code'
+                    input={{}}
+                  />
+                </Layout>
+
+                <Spacer small />
+
+                <Layout>
+                  <Button variant='action'>Confirm your address</Button>
+                </Layout>
+                <Spacer medium />
+              </div>
+              <div>
+                <Layout variant='bordered-buckets' mediumCols={[ 'auto' ]} flex>
+                  <div>'Child 1'</div>
+                  <div>'Child 2'</div>
+                  <div>'Child 3'</div>
+                  <div>'Child 4'</div>
+                  <div>'Child 5'</div>
+                </Layout>
+              </div>
+              <div>
+                This is another section
+              </div>
+            </Modal>
+          </div>
+        )
+      }
+    }
+
+    <ModalExample />
+```
+
+
+```jsx
+  class ModalExample extends React.Component {
+    constructor(props) {
+      super(props)
+
+      this.state = {
+      modalIsOpen: false
+      }
+
+      this.openModal = this.openModal.bind(this);
+      this.closeModal = this.closeModal.bind(this);
+    }
+
+    openModal() {
+      this.setState({
+        modalIsOpen: true
+      });
     }
 
      closeModal() {

--- a/src/molecules/Modal/index.js
+++ b/src/molecules/Modal/index.js
@@ -35,6 +35,7 @@ class Modal extends React.Component {
       className,
       contentLabel,
       header,
+      hideHeader,
       hideX,
       isOpen,
       onAfterOpen,
@@ -53,30 +54,31 @@ class Modal extends React.Component {
       >
         <div className={styles['dialog']}>
           <div className={styles['body']}>
-            <div
-              className={styles['header']}
-            >
-              <Text
-                type={4}
-                font='a'
-              >
-                {header}
-              </Text>
-
+            {
               <div
-                className={styles['close-col']}
+                className={hideHeader ? styles['header-hide'] : styles['header']}
               >
-                {
-                  !hideX &&
-                    <Icon
-                      icon='close'
-                      className={styles['close']}
-                      onClick={onRequestClose}
-                    />
-                }
-              </div>
-            </div>
+                <Text
+                  type={4}
+                  font='a'
+                >
+                  {header}
+                </Text>
 
+                <div
+                  className={styles['close-col']}
+                >
+                  {
+                    !hideX &&
+                      <Icon
+                        icon='close'
+                        className={styles['close']}
+                        onClick={onRequestClose}
+                      />
+                  }
+                </div>
+              </div>
+            }
             {React.Children.map(children, wrapChild)}
           </div>
         </div>
@@ -110,6 +112,11 @@ Modal.propTypes = {
   hideX: PropTypes.bool,
 
   /**
+   * Hide the header section for modal
+   */
+  hideHeader: PropTypes.bool,
+
+  /**
    * Boolean to determine modal open/closed
    */
   isOpen: PropTypes.bool,
@@ -127,12 +134,13 @@ Modal.propTypes = {
   /**
    * variant for modal - options are `simple` (default), `large` & `mobile`
    */
-  variant: PropTypes.oneOf([ 'simple', 'large', 'mobile', 'mobile-large' ]),
+  variant: PropTypes.oneOf([ 'simple', 'large', 'x-large', 'mobile', 'mobile-large' ]),
 };
 
 Modal.defaultProps = {
   variant: 'simple',
-  hideX: false
+  hideX: false,
+  hideHeader: false,
 };
 
 export default Modal;

--- a/src/molecules/Modal/modal.module.scss
+++ b/src/molecules/Modal/modal.module.scss
@@ -19,6 +19,11 @@ $border: 1px solid color('neutral-5');
     z-index: 10;
   }
 
+  &.x-large {
+    max-width: rem-calc(1040);
+    z-index: 10;
+  }
+
   &.mobile {
     margin-top: 0;
     max-width: rem-calc(604);
@@ -65,6 +70,15 @@ $border: 1px solid color('neutral-5');
   display: flex;
   justify-content: space-between;
   padding: ru(1.25) ru(1);
+
+  &-hide {
+    background-color: none;
+    border-bottom: none;
+
+    .close-col {
+      margin: rem-calc(20px);
+    }
+  }
 }
 
 .section {


### PR DESCRIPTION
Adds an "extra-large" variant for Modal, and a prop for hiding the
header in order to make for a more seemless, widget-like modal.


[CH15798](https://app.clubhouse.io/policygenius/story/15798/user-should-be-able-to-enter-the-easy-quiz) 👀  @jmcolella @danielnovograd 