### PR TITLE
Fix proptypes on StyledWrapper

### DIFF
--- a/src/atoms/StyledWrapper/index.js
+++ b/src/atoms/StyledWrapper/index.js
@@ -28,7 +28,11 @@ StyledWrapper.propTypes = {
   /**
    * Any component. Will also take an HTML5 tag name as a string.
    */
-  component: PropTypes.node
+  component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.string
+  ])
 };
 
 StyledWrapper.defaultProps = {


### PR DESCRIPTION
The component prop in styled wrapper is actually the function for a
component or a string. I left in `node` in case that is something that
is actually used, but we might consider removing that if is is not
correct.