### PR TITLE
Update Tooltip and ComparisonTable tooltip

### DIFF
--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -39,6 +39,7 @@ class Tooltip extends React.Component {
       text,
       hoverMessageClassName,
       inline,
+      tooltipIconSize,
     } = this.props;
 
     return (
@@ -57,6 +58,8 @@ class Tooltip extends React.Component {
                 icon='tooltip'
                 className={styles['tooltip']}
                 inline={inline}
+                height={`${tooltipIconSize}px`}
+                width={`${tooltipIconSize}px`}
               />
           }
           <span
@@ -121,6 +124,15 @@ Tooltip.propTypes = {
   inline: PropTypes.oneOf([
     'left', 'right',
   ]),
+
+  /**
+   * Changes height and width of default Tooltip icon. Provide a pixel amount as a number (without the units)
+   */
+  tooltipIconSize: PropTypes.number,
+};
+
+Tooltip.defaultProps = {
+  tooltipIconSize: 12,
 };
 
 export default Tooltip;

--- a/src/atoms/Tooltip/tooltip.module.scss
+++ b/src/atoms/Tooltip/tooltip.module.scss
@@ -1,4 +1,3 @@
-$tooltip-width: ru(.5);
 $tooltip-shift-amount: 60%;
 $hover-message-shift: calc(50% - 3.06rem);
 
@@ -8,8 +7,6 @@ $hover-message-shift: calc(50% - 3.06rem);
 
 .tooltip {
   position: relative;
-  width: $tooltip-width;
-  height: $tooltip-width;
   cursor: help;
   display: inline-block;
 }
@@ -21,7 +18,7 @@ $hover-message-shift: calc(50% - 3.06rem);
   color: color('primary-3');
   font-weight: 400;
   opacity: 0;
-  padding: $tooltip-width;
+  padding: rem-calc(12px);
   position: absolute;
   text-align: left;
   top: calc(100% + 10px);

--- a/src/organisms/tables/ComparisonTable/comparison_table.module.scss
+++ b/src/organisms/tables/ComparisonTable/comparison_table.module.scss
@@ -204,7 +204,7 @@ $border: 1px solid color('neutral-4');
     }
 
     .tooltip {
-      display: block;
+      display: flex;
       margin-left: rem-calc(6px);
     }
 

--- a/src/organisms/tables/ComparisonTable/index.js
+++ b/src/organisms/tables/ComparisonTable/index.js
@@ -101,7 +101,7 @@ class TableRow extends React.Component {
       return (
         <Col key={idx} className={colClass}>
           {child}
-          <Tooltip className={styles['tooltip']}>{subHeader}</Tooltip>
+          <Tooltip className={styles['tooltip']} tooltipIconSize={18}>{subHeader}</Tooltip>
         </Col>
       );
     }


### PR DESCRIPTION
@trevornelson @danielnovograd @Jexeones24 CR please

- Updates `Tooltip` to allow consumer to change width/height of icon
- Updates tooltip used in `ComparisonTable` to be correct size (`18px` as opposed to `12px`)