### PR TITLE
Update PolicyCard styling for easy compare

### DIFF
--- a/src/organisms/cards/SimpleFeaturedPolicyCard/ButtonGroup.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/ButtonGroup.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import Button from 'atoms/Button';
 import LinkWrapper from 'atoms/LinkWrapper';
 import Spacer from 'atoms/Spacer';
+import Text from 'atoms/Text';
+import CheckBoxField from 'molecules/formfields/CheckBoxField';
 
 import styles from './featured_policy_card.module.scss';
 
@@ -14,17 +17,20 @@ function ButtonGroup(props) {
     onCompare,
     continueCTAText,
     detailsCTAText,
+    compareSelected,
+    name
   } = props;
 
   return (
     <div className={styles['button-group']}>
       <Button
         onClick={onContinue}
+        outline={compareSelected}
       >
         {continueCTAText}
       </Button>
 
-      <Spacer spacer={2} />
+      <Spacer size={12} />
       {
         onDetails &&
           <LinkWrapper
@@ -36,9 +42,28 @@ function ButtonGroup(props) {
 
       }
 
-      <Button outline onClick={onCompare} >
-        Compare
-      </Button>
+      <div
+        id={`${name}-checkbox-wrapper`}
+        className={styles['checkbox-wrapper']}
+        onClick={onCompare}
+      >
+        <Text
+          size={10}
+          font='b'
+          className={classnames(compareSelected && styles['checked'])}
+        >
+          Compare
+        </Text>
+        <Spacer spacer={1} />
+        <div className={styles['checkbox-field']}>
+          <CheckBoxField
+            input={{
+              value: compareSelected,
+              name
+            }}
+          />
+        </div>
+      </div>
     </div>
   );
 }
@@ -49,6 +74,8 @@ ButtonGroup.propTypes = {
   onCompare: PropTypes.func,
   continueCTAText: PropTypes.string,
   detailsCTAText: PropTypes.string,
+  compareSelected: PropTypes.bool,
+  name: PropTypes.string,
 };
 
 ButtonGroup.defaultProps = {

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/Readme.md
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/Readme.md
@@ -14,6 +14,10 @@
         defaultText: 'Quote available from a PolicyGenius expert'
       }}
       onDetails={() => alert('details button clicked')}
-      onCompare={() => alert('compare button clicked')}
+      compareCheckbox={{
+        onCompare: (e) => setState({ compare: e.target.checked }),
+        compareSelected: state.compare,
+        name: 'unique-name'
+      }}
     />
 ```

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/__snapshots__/simple_featured_policy_card.spec.js.snap
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/__snapshots__/simple_featured_policy_card.spec.js.snap
@@ -45,16 +45,42 @@ exports[`<SimpleFeaturedPolicyCard /> renders correctly 1`] = `
         Continue
       </button>
       <div
-        className="top-2"
+        className="size-12"
       />
-      <button
-        className="button outline"
-        disabled={undefined}
-        onClick={undefined}
-        type="button"
+      <div
+        className="checkbox-wrapper"
+        id="a_unique_name-checkbox-wrapper"
+        onClick={[Function]}
       >
-        Compare
-      </button>
+        <p
+          className="primary-3 type-b-10-medium inherit"
+        >
+          Compare
+        </p>
+        <div
+          className="top-1"
+        />
+        <div
+          className="checkbox-field"
+        >
+          <label
+            className="checkbox"
+            htmlFor="checkbox-a_unique_name"
+          >
+            <input
+              checked={false}
+              className="checkbox-input"
+              id="checkbox-a_unique_name"
+              name="a_unique_name"
+              type="checkbox"
+              value={false}
+            />
+            <span
+              className="checkbox-label"
+            />
+          </label>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/simple_featured_policy_card.spec.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/__tests__/simple_featured_policy_card.spec.js
@@ -14,7 +14,12 @@ describe('<SimpleFeaturedPolicyCard />', () => {
         price: 19.8,
         format: 'mo'
       },
-      onDetails: jest.fn()
+      onDetails: jest.fn(),
+      compareCheckbox: {
+        onCompare: jest.fn(),
+        compareSelected: false,
+        name: 'a_unique_name',
+      }
     };
   });
 

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/featured_policy_card.module.scss
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/featured_policy_card.module.scss
@@ -11,6 +11,10 @@ $details-link-border: 1px solid #b2b2b2;
   flex-direction: column;
   height: 100%;
 
+  &.selected {
+    border: 1px solid color('secondary-2');
+  }
+
   .details-link {
     @include typography-7(false);
 
@@ -58,6 +62,16 @@ $details-link-border: 1px solid #b2b2b2;
   width: 100%;
   text-align: center;
   margin-top: auto;
+}
+
+.checkbox-wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  .checkbox-field {
+    margin-left: rem-calc(12px);
+  }
 }
 
 @media #{$small-only} {

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
@@ -15,11 +15,12 @@ function SimpleFeaturedPolicyCard(props) {
     premium,
     carrierLogo,
     onContinue,
-    onCompare,
+    compareCheckbox
   } = props;
 
   const classes = [
     styles['featured-policy-card'],
+    compareCheckbox.compareSelected && styles['selected'],
     className,
   ];
 
@@ -51,7 +52,7 @@ function SimpleFeaturedPolicyCard(props) {
 
         <ButtonGroup
           onContinue={onContinue}
-          onCompare={onCompare}
+          {...compareCheckbox}
         />
       </div>
     </div>
@@ -111,9 +112,15 @@ SimpleFeaturedPolicyCard.propTypes = {
   onDetails: PropTypes.func,
 
   /**
-   * Function supplied to compare CTA on mobile only
+   * Props for the Checkbox to compare
+   *
+   * NOTE: `name` must be unique
    */
-  onCompare: PropTypes.func,
+  compareCheckbox: PropTypes.shape({
+    onCompare: PropTypes.func.isRequired,
+    compareSelected: PropTypes.bool,
+    name: PropTypes.string,
+  }),
 
   /**
    * Supplies information about policy to card. Examples would include type, financial strength or total customers

--- a/src/organisms/cards/SimplePolicyCard/PolicyActions.js
+++ b/src/organisms/cards/SimplePolicyCard/PolicyActions.js
@@ -5,13 +5,14 @@ import Button from 'atoms/Button';
 import styles from './policy_card.module.scss';
 
 export const PolicyActions = (props) => {
-  const { onContinue, continueCTAText } = props;
+  const { onContinue, continueCTAText, selected } = props;
 
   return (
     <div className={styles['actions']}>
       <Layout smallCols={[ 12 ]} style={{ width: '100%' }} fullwidth>
         <Button
           onClick={onContinue}
+          outline={selected}
         >
           {continueCTAText}
         </Button>
@@ -23,7 +24,8 @@ export const PolicyActions = (props) => {
 PolicyActions.propTypes = {
   onContinue: PropTypes.func.isRequired,
   continueCTAText: PropTypes.func,
-  onDetails: PropTypes.func
+  onDetails: PropTypes.func,
+  selected: PropTypes.bool,
 };
 
 PolicyActions.defaultProps = {

--- a/src/organisms/cards/SimplePolicyCard/Readme.md
+++ b/src/organisms/cards/SimplePolicyCard/Readme.md
@@ -1,6 +1,7 @@
 ### SimplePolicyCard Example:
 
 ```jsx
+  <div>
     <SimplePolicyCard
       carrierLogo={
         <img
@@ -21,4 +22,28 @@
         name: 'unique-name'
       }}
     />
+
+    <Spacer size={24} />
+
+    <SimplePolicyCard
+      carrierLogo={
+        <img
+          src='https://cdn-staging.policygenius.com/assets/insurance-cards-logos/banner-life-dark-2x-c02aef5dc27115997f3185217e684806.png'
+          alt='hello'
+        />
+      }
+      premium={{
+        price: 13,
+        format: 'mo',
+        defaultText: 'Quote available from a PolicyGenius expert'
+      }}
+      onContinue={() => alert('continue button clicked')}
+      onDetails={() => alert('details button clicked')}
+      compareCheckbox={{
+        onCompare: (e) => setState({ compare: e.target.checked }),
+        compareSelected: true,
+        name: 'unique-name-2'
+      }}
+    />
+  </div>
 ```

--- a/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
+++ b/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
@@ -49,16 +49,42 @@ exports[`<SimplePolicyCard /> renders correctly 1`] = `
             Continue
           </button>
           <div
-            className="top-2"
+            className="size-12"
           />
-          <button
-            className="button outline"
-            disabled={undefined}
+          <div
+            className="checkbox-wrapper"
+            id="undefined-checkbox-wrapper"
             onClick={[Function]}
-            type="button"
           >
-            Compare
-          </button>
+            <p
+              className="primary-3 type-b-10-medium inherit"
+            >
+              Compare
+            </p>
+            <div
+              className="top-1"
+            />
+            <div
+              className="checkbox-field"
+            >
+              <label
+                className="checkbox"
+                htmlFor="checkbox-undefined"
+              >
+                <input
+                  checked={undefined}
+                  className="checkbox-input"
+                  id="checkbox-undefined"
+                  name={undefined}
+                  type="checkbox"
+                  value={undefined}
+                />
+                <span
+                  className="checkbox-label"
+                />
+              </label>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/organisms/cards/SimplePolicyCard/index.js
+++ b/src/organisms/cards/SimplePolicyCard/index.js
@@ -16,8 +16,15 @@ function SimplePolicyCard(props) {
     premium,
     onContinue,
     compareCheckbox,
-    className
+    className,
+    anyCardSelected,
   } = props;
+
+  const policyCardClasses = classnames(
+    styles['policy-card'],
+    compareCheckbox.compareSelected && styles['selected'],
+    className
+  );
 
   return (
     <div>
@@ -26,10 +33,10 @@ function SimplePolicyCard(props) {
           premium={premium}
           carrierLogo={carrierLogo}
           onContinue={onContinue}
-          onCompare={compareCheckbox.onCompare}
+          compareCheckbox={compareCheckbox}
         />
       </div>
-      <div className={classnames(styles['policy-card'], className)}>
+      <div className={policyCardClasses}>
         <div className={styles['body']}>
           <Compare {...compareCheckbox} />
           <div className={styles['divider']} />
@@ -40,6 +47,7 @@ function SimplePolicyCard(props) {
             onContinue={onContinue}
             onCompare={compareCheckbox.onCompare}
             premium={premium}
+            selected={compareCheckbox.compareSelected || anyCardSelected}
           />
         </div>
       </div>

--- a/src/organisms/cards/SimplePolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/SimplePolicyCard/policy_card.module.scss
@@ -18,6 +18,10 @@ $footer: #f6f6f6;
   border: 1px solid $border;
   background-color: color('neutral-8');
   display: none;
+
+  &.selected {
+    border: 1px solid color('secondary-2');
+  }
 }
 
 .body {

--- a/src/organisms/cards/SimplePolicyCard/propTypes.js
+++ b/src/organisms/cards/SimplePolicyCard/propTypes.js
@@ -53,5 +53,10 @@ export default {
     onCompare: PropTypes.func.isRequired,
     compareSelected: PropTypes.bool,
     name: PropTypes.string,
-  })
+  }),
+
+  /**
+   * Boolean to toggle styling for Continue CTA if any other card in the group is selected
+   */
+  anyCardSelected: PropTypes.bool,
 };


### PR DESCRIPTION
@trevornelson @danielnovograd @Jexeones24 CR please

[CH 17105](https://app.clubhouse.io/policygenius/story/17105/shoppers-should-see-styling-entering-in-the-compare-experience)

- Updates styling of `SimplePolicyCard` to have blue outline and outline Continue CTA when selected for comparison
- Adds `anyCardSelected` prop to `SimplePolicyCard` to add selected state for Continue CTA if any card in a group of `SimplePolicyCard`s is selected
- Adds a compare checkbox instead of button to `SimpleFeaturedPolicyCard` along with blue border and outline Continue CTA when selected for comparison