### PR TITLE
Fix Sections undefined background image

### DIFF
--- a/src/atoms/Section/__tests__/__snapshots__/section.spec.js.snap
+++ b/src/atoms/Section/__tests__/__snapshots__/section.spec.js.snap
@@ -6,7 +6,7 @@ exports[`<Section /> renders correctly 1`] = `
   id={undefined}
   style={
     Object {
-      "backgroundImage": "url(undefined)",
+      "backgroundImage": undefined,
     }
   }
 >

--- a/src/atoms/Section/index.js
+++ b/src/atoms/Section/index.js
@@ -36,7 +36,7 @@ function Section(props) {
       className={classnames(...classes)}
       style={{
         ...style,
-        backgroundImage: `url(${backgroundImageUrl})`
+        backgroundImage: backgroundImageUrl ? `url(${backgroundImageUrl})` : undefined
       }}
     >
       <div className={styles.wrapper}>


### PR DESCRIPTION
If no backgroundImageUrl was supplied to Section, it was inlining a
background-image url('undefined')

This was also creating multiple errors in Sentry