### PR TITLE
Modify ToggleField and Modal components

### DIFF
--- a/src/molecules/Modal/modal.module.scss
+++ b/src/molecules/Modal/modal.module.scss
@@ -110,10 +110,13 @@ $border: 1px solid color('neutral-5');
   }
 
   .mobile,
-  .mobile-large,
-  .x-large {
+  .mobile-large {
     padding: 0;
     margin: 0;
+  }
+  .x-large {
+    padding: 0;
+    margin-top: rem-calc(60);
   }
 }
 

--- a/src/molecules/formfields/ToggleField/index.js
+++ b/src/molecules/formfields/ToggleField/index.js
@@ -51,6 +51,8 @@ function ToggleField( props ) {
     input,
     meta,
     noBorder,
+    nested,
+    sideBySide,
   } = props;
 
   const classes = [
@@ -64,10 +66,14 @@ function ToggleField( props ) {
 
   const message = meta && meta.touched && !meta.active && (meta.error || meta.warning);
 
+  const buttonStyle = sideBySide ? styles['side-by-side'] : styles['button-wrapper'];
+
   return (
     <div>
       <div className={classnames(...classes)}>
-        <Layout>
+        <Layout
+          nested={nested}
+        >
           { label &&
             <Col className={styles['header']}>
               { tooltip &&
@@ -79,7 +85,7 @@ function ToggleField( props ) {
             </Col>
           }
           { children && <Col className={styles['body']}>{children}</Col> }
-          <Col className={styles['button-wrapper']}>
+          <Col className={buttonStyle}>
             { renderChoices(toggleChoices, input) }
           </Col>
         </Layout>
@@ -137,6 +143,16 @@ ToggleField.propTypes = {
    * Removes border surrouding label and buttons
    */
   noBorder: PropTypes.bool,
+
+  /**
+   * When present, nested is a prop passed directly to the layout component wrapping the ToggleField to remove ~6px left/right margin.
+  **/
+  nested: PropTypes.bool,
+
+  /** When present, sideBySide prop keeps buttons side-by-side on mobile
+   *
+  **/
+  sideBySide: PropTypes.bool,
 };
 
 export default ToggleField;

--- a/src/molecules/formfields/ToggleField/toggle_field.module.scss
+++ b/src/molecules/formfields/ToggleField/toggle_field.module.scss
@@ -58,6 +58,20 @@
   margin-bottom: ru(.25);
 }
 
+.side-by-side {
+  display: flex;
+  flex-direction: row;
+
+  .button {
+    margin-left: ru(1);
+    margin-bottom: 0;
+
+    &:first-of-type {
+      margin-left: 0;
+    }
+  }
+}
+
 /* --  state:focus  -- */
 .focused {
   @extend %focused;


### PR DESCRIPTION
[CH16965](https://app.clubhouse.io/policygenius/story/16965/shopper-should-see-design-polish-updates-to-the-easy-quiz)

Adds a `nested` prop to remove ~6px left/right margin from Layout component wrapping the buttons and `sideBySide` prop to prevent the buttons from stacking on mobile. Also, added 60px of margin-top to x-large `Modal` variant as this is the one being used in the Easy Quiz. 