### PR TITLE
Make react-styleguidist a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-input-mask": "^0.8.0",
     "react-modal": "^3.1.6",
     "react-stickynode": "^1.4.0",
-    "react-styleguidist": "^6.0.26",
     "react-transition-group": "^1.1.3",
     "shortid": "^2.2.8",
     "styled-components": "^2.2.1"
@@ -111,6 +110,7 @@
     "react-addons-test-utils": "^16.0.0-alpha.3",
     "react-dom": "^16.2.0",
     "react-hot-loader": "^3.1.3",
+    "react-styleguidist": "^6.0.26",
     "react-test-renderer": "^16.0.0",
     "remark-cli": "^3.0.0",
     "remark-lint": "^6.0.0",


### PR DESCRIPTION
React-styleguidist is only necessary for creating the RCL app, but it's
not necessary as part of the npm package we create.