### PR TITLE
Fix fragment and proptype errors

### DIFF
--- a/src/molecules/StepIndicator/ProgressBarStep.js
+++ b/src/molecules/StepIndicator/ProgressBarStep.js
@@ -13,13 +13,13 @@ export default class ProgressBarStep extends Component {
     if (step.currentStepActive) {
       return {
         color: 'primary-3',
-        weight: 'semibold',
+        bold: true,
       };
     }
 
     return {
       color: 'neutral-3',
-      weight: 'semibold'
+      bold: true
     };
   }
 

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
@@ -64,14 +64,14 @@ function SimpleFeaturedPolicyCard(props) {
 
         {
           onContinue &&
-            [
-              <Spacer size={36} />,
+            <React.Fragment>
+              <Spacer size={36} />
               <ButtonGroup
                 onContinue={onContinue}
                 compareCheckbox={compareCheckbox}
                 continueCTAText={continueCTAText}
               />
-            ]
+            </React.Fragment>
         }
       </div>
     </div>

--- a/src/organisms/cards/SimplePolicyCard/Compare.js
+++ b/src/organisms/cards/SimplePolicyCard/Compare.js
@@ -8,7 +8,7 @@ import CheckBoxField from 'molecules/formfields/CheckBoxField';
 import styles from './policy_card.module.scss';
 
 const Compare = ({ compareSelected, onCompare, name }) =>
-  <Hide hideOn='small' className={styles['compare']}>
+  <Hide hideOn='mobile' className={styles['compare']}>
     <div
       id={`${name}-checkbox-wrapper`}
       className={styles['checkbox-wrapper']}

--- a/src/organisms/cards/SimplePolicyCard/PolicyActions.js
+++ b/src/organisms/cards/SimplePolicyCard/PolicyActions.js
@@ -23,7 +23,7 @@ export const PolicyActions = (props) => {
 
 PolicyActions.propTypes = {
   onContinue: PropTypes.func.isRequired,
-  continueCTAText: PropTypes.func,
+  continueCTAText: PropTypes.string,
   onDetails: PropTypes.func,
   selected: PropTypes.bool,
 };

--- a/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
+++ b/src/organisms/cards/SimplePolicyCard/__tests__/__snapshots__/simple_policy_card.spec.js.snap
@@ -47,7 +47,7 @@ exports[`<SimplePolicyCard /> renders correctly 1`] = `
         className="compare-logo-section"
       >
         <div
-          className="hide compare small"
+          className="hide compare mobile"
         >
           <div
             className="checkbox-wrapper"

--- a/src/organisms/cards/SimplePolicyCard/index.js
+++ b/src/organisms/cards/SimplePolicyCard/index.js
@@ -46,13 +46,11 @@ function SimplePolicyCard(props) {
         <div className={styles['body']}>
           <div className={styles['compare-logo-section']}>
             {
-              !isEmpty(compareCheckbox) ?
-              [
-                <Compare {...compareCheckbox} />,
+              !isEmpty(compareCheckbox) &&
+              <React.Fragment>
+                <Compare {...compareCheckbox} />
                 <div className={styles['divider']} />
-              ]
-              :
-              null
+              </React.Fragment>
             }
             <CarrierLogo carrierLogo={carrierLogo} />
           </div>

--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -84,6 +84,7 @@ function renderPhoneInfo(phoneNumber, hours) {
         {
           hours && hours.map(hour =>
             <Text
+              key={hour}
               size={10}
               font='b'
             >


### PR DESCRIPTION
Cleans up some errors we were getting in life-web due to fragment array syntax and deprecated prop types.

[Corresponding PR](https://github.com/policygenius/life-web/pull/894)

@jmcolella @drewdrewthis @Jexeones24 