### PR TITLE
Update all stylesheet imports to relative

### DIFF
--- a/src/assets/stylesheets/_global.scss
+++ b/src/assets/stylesheets/_global.scss
@@ -1,8 +1,8 @@
-@import 'assets/stylesheets/base_styles/typography';
-@import 'assets/stylesheets/base_styles/colors';
-@import 'assets/stylesheets/utilities/functions';
-@import 'assets/stylesheets/utilities/mixins';
-@import 'assets/stylesheets/utilities/break_points';
-@import 'assets/stylesheets/utilities/variables';
-@import 'assets/stylesheets/utilities/placeholders';
-@import 'assets/stylesheets/base_styles/spacing';
+@import 'base_styles/typography';
+@import 'base_styles/colors';
+@import 'utilities/functions';
+@import 'utilities/mixins';
+@import 'utilities/break_points';
+@import 'utilities/variables';
+@import 'utilities/placeholders';
+@import 'base_styles/spacing';

--- a/src/assets/stylesheets/base.scss
+++ b/src/assets/stylesheets/base.scss
@@ -1,2 +1,2 @@
-@import 'assets/stylesheets/base_styles/sanitize';
-@import 'assets/stylesheets/base_styles/pg_normalize';
+@import 'base_styles/sanitize';
+@import 'base_styles/pg_normalize';

--- a/src/assets/stylesheets/utilities/_break_points.scss
+++ b/src/assets/stylesheets/utilities/_break_points.scss
@@ -1,4 +1,4 @@
-@import 'assets/stylesheets/utilities/functions';
+@import 'functions';
 
 $page-max-width: 80.5rem;
 


### PR DESCRIPTION
@danielnovograd @drewdrewthis @trevornelson CR please

In order to properly import athenaeum stylesheets into other services, life `life-web`, all internal scss imports within the athenaeum stylesheets must use relative paths instead of absolute paths. The main issue is that, when trying to import a stylesheet that uses an absolute path, webpack cannot resolve that path correctly. It seems that other major UI libraries, like Bootstrap, have organized their internal scss stylesheets in this manner and have allowed consumers to import their stylesheets without issue.

I have tested this in both `life-web` and locally in `athenaeum`. This new relative path system should work. We will need to update `pg-gatsby`'s imports once this is merged in.