### PR TITLE
Turn off lazy load warnings

### DIFF
--- a/src/atoms/Icon/index.js
+++ b/src/atoms/Icon/index.js
@@ -5,17 +5,7 @@ import { icons as ICONS } from './constants';
 
 import styles from './icons.module.scss';
 
-const checkLS = () => {
-  if (typeof window !== 'undefined' && !window.lazySizes) {
-    /* eslint-disable no-console */
-    console.warn('lazysizes not loaded.');
-    /* eslint-enable no-console */
-
-    return false;
-  }
-
-  return true;
-};
+const checkLS = () => typeof window === 'undefined' || !!window.lazySizes;
 
 function Icon( props ) {
   const {

--- a/src/atoms/Img/index.js
+++ b/src/atoms/Img/index.js
@@ -3,17 +3,8 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import styles from './img.module.scss';
 
-const checkLS = () => {
-  if (typeof window !== 'undefined' && !window.lazySizes) {
-    /* eslint-disable no-console */
-    console.warn('lazysizes not loaded.');
-    /* eslint-enable no-console */
+const checkLS = () => typeof window === 'undefined' || !!window.lazySizes;
 
-    return false;
-  }
-
-  return true;
-};
 const strParams = '?fit=max&auto=format&ch=Width,DPR&w={width}';
 const imgixSrcStr = src => `https://policygenius-images.imgix.net/${src}${strParams}`;
 const imgixSrcset = src => `


### PR DESCRIPTION
Turns off warnings about lazy loader for people who want to use athenaeum without going mad. I've heard there are potentially reasons why this is important, but, if there is, there should be a better way to let a dev know than spamming the console.

@jmcolella @drewdrewthis @sunnymis 