### PR TITLE
Add React SVG Inline to Icon component

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-input-mask": "^0.8.0",
     "react-modal": "^3.1.6",
     "react-stickynode": "^1.4.0",
+    "react-svg-inline": "^2.1.0",
     "react-transition-group": "^1.1.3",
     "shortid": "^2.2.8",
     "styled-components": "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,7 +2125,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.0.0, classnames@^2.2.5:
+classnames@^2.0.0, classnames@^2.2.1, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -10530,6 +10530,13 @@ react-styleguidist@^6.0.26:
     unist-util-visit "^1.3.0"
     webpack-dev-server "^2.9.7"
     webpack-merge "^4.1.1"
+
+react-svg-inline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-svg-inline/-/react-svg-inline-2.1.0.tgz#1ee3a1a2b2ca0b3629822cddd5327a1125c0184f"
+  dependencies:
+    classnames "^2.2.1"
+    prop-types "^15.5.8"
 
 react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
   version "16.2.0"


### PR DESCRIPTION
@sunnymis @drewdrewthis CR please

The need to style SVG inline DOM elements has come back so this PR adds back to the `Icon` component the `react-inline-svg` library to handle such requests.

The `Icon` component is now responsible for fetching the SVG DOM string if the prop `renderSVGDOM` is passed to the component, which will allow the `react-inline-svg` library to properly render the SVG DOM.

[This commit](https://github.com/policygenius/athenaeum/commit/2197be9c3cd44bebb525f590c29e616e42ad9ea0#diff-24f58e1099d598242f386620a82590c3R3) removed the `react-inline-svg` library in favor of another inline library that handles URLs under the hood.

[This PR](https://github.com/policygenius/athenaeum/pull/621) then removes that new library from the previous commit due to errors in Gatsby.

It seems moving back to `react-inline-svg` will be a fine move for development in Gatsby since it didn't pose errors before. We just needed to add a little extra logic to give this library the correct props to work.