### PR TITLE
Manually Bump Version to 8.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athenaeum",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "description": "PolicyGenius React Component Library (RCL)",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
For some reason the npm version and the version on GitHub became out of
sync. Testing to see if this fixes it

@PepperTeasdale 