### PR TITLE
Fix modal background scroll for iOS devices

### DIFF
--- a/src/molecules/Modal/index.js
+++ b/src/molecules/Modal/index.js
@@ -8,6 +8,7 @@ import Icon from 'atoms/Icon';
 import MobileMenu from 'molecules/MobileMenu';
 import styles from './modal.module.scss';
 import mobileScrollToInput from './util/mobileScrollToInput';
+import checkiOSDevice from './util/checkiOSDevice';
 
 const wrapChild = (child) => {
   if (child.type === MobileMenu) return child;
@@ -53,6 +54,15 @@ class Modal extends React.Component {
 
     document.body.style.overflow = 'hidden';
 
+    if (checkiOSDevice(navigator.userAgent)) {
+      this.setState({
+        windowPosition: window.pageYOffset,
+      });
+
+      document.body.style.position = 'fixed';
+      document.body.style.width = '100%';
+    }
+
     if (onAfterOpen) {
       onAfterOpen();
     }
@@ -62,6 +72,11 @@ class Modal extends React.Component {
     const { onRequestClose } = this.props;
 
     document.body.style.overflow = this.state.initialBodyOverflow;
+
+    if (checkiOSDevice(navigator.userAgent)) {
+      document.body.style.position = '';
+      window.scrollTo(0, this.state.windowPosition);
+    }
 
     if (onRequestClose) {
       onRequestClose();

--- a/src/molecules/Modal/util/checkiOSDevice.js
+++ b/src/molecules/Modal/util/checkiOSDevice.js
@@ -1,0 +1,10 @@
+export default (userAgent) => {
+  const iPhone = /iPhone/i;
+  const iPod = /iPod/i;
+  const iPad = /iPad/i;
+  const windows = /Windows Phone|IEMobile|WPDesktop/i;
+
+  const isiPhone = iPhone.test(userAgent) && !iPad.test(userAgent) && !windows.test(userAgent);
+
+  return iPad.test(userAgent) || iPod.test(userAgent) || isiPhone;
+};


### PR DESCRIPTION
@drewdrewthis @danielnovograd @Jexeones24 @trevornelson CR please

When updating the `Modal` to not allow for a background scroll, iOS devices did not respect the styling applied to the `body` to prevent that. This PR further updates the logic to prevent scroll by targeting iOS devices using the `navigator.userAgent` property and applying further `body` styling to ensure there is not background scroll when a modal is open on iOS. The logic also ensures that when a user closes the modal, they are brought back to the spot on the page where the modal had initially opened.