### PR TITLE
Check that modal is found before setting scrollTo attribute

### DIFF
--- a/src/molecules/Modal/util/mobileScrollToInput.js
+++ b/src/molecules/Modal/util/mobileScrollToInput.js
@@ -7,7 +7,9 @@ const scrollToInput = () => {
 
   const calc = elementDistanceFromTop(parent) - (window.innerHeight / 2);
 
-  modal.scrollTop = calc;
+  if (modal) {
+    modal.scrollTop = calc;
+  }
 };
 
 export default (dialogId) => {


### PR DESCRIPTION
[Sentry Issue 40874](https://exceptions.policygenius.com/policygenius/life/issues/40874/) seems to be throwing a really noisy error when `scrollToTop` is called when `React__Overlay` isn't available yet. Doesn't seem like this actually ends up creating an end user issue though.

👁 @jmcolella @Jexeones24 