### PR TITLE
Update Modal component

### DIFF
--- a/src/molecules/Modal/Readme.md
+++ b/src/molecules/Modal/Readme.md
@@ -253,3 +253,53 @@ This uses [`ReactModal`](https://github.com/reactjs/react-modal) under the hood 
     <ModalExample />
 ```
 
+```jsx
+  class ModalExample extends React.Component {
+    constructor(props) {
+      super(props)
+
+      this.state = {
+      modalIsOpen: false
+      }
+
+      this.openModal = this.openModal.bind(this);
+      this.closeModal = this.closeModal.bind(this);
+    }
+
+    openModal() {
+      this.setState({
+        modalIsOpen: true
+      });
+     }
+
+     closeModal() {
+        this.setState({
+          modalIsOpen: false
+        });
+      }
+
+      render() {
+        return (
+          <div>
+            <Button onClick={this.openModal}>Open Styled Sections Modal</Button>
+
+            <Modal
+              hideHeader
+              onRequestClose={this.closeModal}
+              isOpen={this.state.modalIsOpen}
+              contentLabel='Modal'
+              sectionClassName='example-section-class'
+            >
+            <div>'Child 1'</div>
+            <div>'Child 2'</div>
+            <div>'Child 3'</div>
+            <div>'Child 4'</div>
+            <div>'Child 5'</div>
+            </Modal>
+            </div>
+        )
+      }
+    }
+
+    <ModalExample />
+```

--- a/src/molecules/Modal/index.js
+++ b/src/molecules/Modal/index.js
@@ -11,20 +11,6 @@ import styles from './modal.module.scss';
 import mobileScrollToInput from './util/mobileScrollToInput';
 import checkiOSDevice from './util/checkiOSDevice';
 
-const wrapChild = (child) => {
-  if (child.type === MobileMenu) return child;
-
-  return React.createElement(
-    'div',
-    {
-      className: classnames(
-        styles['section'],
-      )
-    },
-    child
-  );
-};
-
 class Modal extends React.Component {
   constructor() {
     super();
@@ -101,6 +87,21 @@ class Modal extends React.Component {
     }
   }
 
+  wrapChild = (child) => {
+    if (child.type === MobileMenu) return child;
+
+    return React.createElement(
+      'div',
+      {
+        className: classnames(
+          styles['section'],
+          this.props.sectionClassName
+        )
+      },
+      child
+    );
+  };
+
   render() {
     const {
       children,
@@ -155,7 +156,7 @@ class Modal extends React.Component {
 
                 </div>
             }
-            {React.Children.map(children, wrapChild)}
+            {React.Children.map(children, this.wrapChild)}
           </div>
         </div>
       </ReactModal>
@@ -220,7 +221,12 @@ Modal.propTypes = {
   /**
    * Enables the ability for the modal to scroll input fields to the center of mobile screen when soft keyboard is activate. MUST provide a `dialogId` prop for targeting inputs correctly
    */
-  enableMobileScrollToInput: PropTypes.bool
+  enableMobileScrollToInput: PropTypes.bool,
+
+  /**
+   * Enables the ability to override styling of child sections. Apply className to the Modal component and the corresponding styles in your stylesheet
+   */
+  sectionClassName: PropTypes.string
 };
 
 Modal.defaultProps = {

--- a/styleguide_assets/rcl_styles.module.scss
+++ b/styleguide_assets/rcl_styles.module.scss
@@ -9,8 +9,11 @@ in the policygenius/react-styleguidist rep
 Complicated css nesting that jss doesn't handle well is best placed here.
 
  */
-
 :global{
+  // src/molecules/Modal/Readme.md
+  .example-section-class {
+    outline: 1px solid red;
+  }
 
   body {
     .RCL-Logo {


### PR DESCRIPTION
Corresponds to [CH21165](https://app.clubhouse.io/policygenius/story/21165/return-shoppers-on-the-homepage-or-landing-page-should-see-the-launchpad)

- Adds a `sectionClassName` prop to `Modal` component allowing control over children styles

CR @drewdrewthis @danielnovograd 