### PR TITLE
Add lazy flag for each item in IconList

### DIFF
--- a/src/atoms/CircularLoader/__tests__/__snapshots__/circular_loader.spec.js.snap
+++ b/src/atoms/CircularLoader/__tests__/__snapshots__/circular_loader.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CircularLoader /> renders correctly 1`] = `
+<div
+  className="circular-loader"
+/>
+`;

--- a/src/molecules/lists/IconList/index.js
+++ b/src/molecules/lists/IconList/index.js
@@ -35,6 +35,7 @@ function IconList(props) {
               <Icon
                 className={styles.icon}
                 icon={item.icon}
+                lazy={typeof item.lazy === 'undefined' ? true : item.lazy}
                 inline
               />
               {item.text}
@@ -83,7 +84,8 @@ IconList.propTypes = {
    */
   data: PropTypes.arrayOf(PropTypes.shape({
     item: PropTypes.string,
-    icon: PropTypes.string
+    icon: PropTypes.string,
+    lazy: PropTypes.bool,
   })).isRequired,
 };
 


### PR DESCRIPTION
@danielnovograd @Jexeones24 @sunnymis CR please

Adds the ability to pass a `lazy` flag for each item in `data` supplied to the `IconList`. This gives us the flexibility to use the `IconList` when doing something like SSR, where lazy load is not necessary. 