### PR TITLE
add tag prop to BlockHeader

### DIFF
--- a/src/molecules/BlockHeader/Readme.md
+++ b/src/molecules/BlockHeader/Readme.md
@@ -7,6 +7,7 @@
     supertitle='Super title dawg'
     title='Title dawg'
     description='Here is a super cool description and it is so cool'
+    tag='h1'
   />
 ```
 

--- a/src/molecules/BlockHeader/index.js
+++ b/src/molecules/BlockHeader/index.js
@@ -16,7 +16,8 @@ const BlockHeader = ({
   className,
   children,
   leftOffset,
-  verticalPadding
+  verticalPadding,
+  tag
 }) =>
   <GrayBox
     cols={cols}
@@ -31,7 +32,7 @@ const BlockHeader = ({
       <Text variant='label' className={styles.label}>
         {supertitle}
       </Text>
-      <Text tag='h2' className={styles.title} font='a' size={2}>
+      <Text tag={tag} className={styles.title} font='a' size={2}>
         {title}
       </Text>
       <Text className={styles.description} font='b' size={9}>
@@ -81,7 +82,15 @@ BlockHeader.propTypes = {
   /**
    * Number of columns to push the title to the right, eg `3`
    */
-  leftOffset: PropTypes.number
+  leftOffset: PropTypes.number,
+  /**
+   * The tag to be used for the header. Defaults to h2
+   */
+  tag: PropTypes.string
+};
+
+BlockHeader.defaultProps = {
+  tag: 'h2'
 };
 
 export default BlockHeader;


### PR DESCRIPTION
[CH ticket](https://app.clubhouse.io/policygenius/story/17993/users-should-see-the-insurance-carrier-title-as-an-h1-tag)

We already specify a `tag` attribute in the `CarrierReviewHeader` component in gatsby - we just hadn't been supporting that prop in the RCL. I think it makes sense to add support rather than hardcoding it to be a `h2` in the component, as we don't know what downstream effects that might have.

👁 pls @sunnymis @jl08 