### PR TITLE
Add optional subtitles to StepIndicator

### DIFF
--- a/src/molecules/StepIndicator/ProgressBarStep.js
+++ b/src/molecules/StepIndicator/ProgressBarStep.js
@@ -5,21 +5,25 @@ import classnames from 'classnames';
 import styles from './step_indicator.module.scss';
 
 export default class ProgressBarStep extends Component {
-  textProps() {
+  titleProps() {
     const {
-      step
+      step: { currentStepActive }
     } = this.props;
 
-    if (step.currentStepActive) {
-      return {
-        color: 'primary-3',
-        bold: true,
-      };
-    }
+    return {
+      color: currentStepActive ? 'primary-3' : 'neutral-3',
+      bold: true
+    };
+  }
+
+  subtitleProps() {
+    const {
+      step: { currentStepActive }
+    } = this.props;
 
     return {
-      color: 'neutral-3',
-      bold: true
+      color: currentStepActive ? 'primary-3' : 'neutral-3',
+      bold: currentStepActive
     };
   }
 
@@ -49,44 +53,57 @@ export default class ProgressBarStep extends Component {
 
   textClasses() {
     const {
+      clickable,
       step
     } = this.props;
 
     return [
       styles['step-wrapper'],
-      step.clickable && styles['step-wrapper-clickable'],
+      clickable && step.clickable && styles['step-wrapper-clickable'],
       !step.currentStepActive && styles['step-wrapper-inactive']
     ];
   }
 
-  handleClick = () => {
+  clickProps() {
     const {
+      clickable,
+      navigateToPath,
       step,
-      navigateToPath
     } = this.props;
 
-    if (step.clickable) {
-      navigateToPath(step.route);
-    }
+    return !clickable ? {
+      onClick: () => {
+        if (step.clickable) {
+          navigateToPath(step.route);
+        }
+      }
+    } : null;
   }
 
   render() {
     const { step } = this.props;
 
     return (
-      <div className={styles['breadcrumb']} onClick={this.handleClick}>
+      <div className={styles['breadcrumb']} {...this.clickProps()}>
         <div className={classnames(this.textClasses())}>
-          <Text tag='span' type={11} font='a' spaced className={styles['step-title']} {...this.textProps()}>{ step.text }</Text>
+          <Text tag='span' type={11} font='a' spaced className={styles['step-title']} {...this.titleProps()}>{ step.text }</Text>
         </div>
         <div className={classnames(...this.circleWrapperClasses())}>
           <div className={classnames(...this.circleClasses())} />
         </div>
+        {
+          step.subtitle &&
+          <div className={styles['step-subtitle']}>
+            <Text tag='span' type={9} font='b' {...this.subtitleProps()}>{step.subtitle}</Text>
+          </div>
+        }
       </div>
     );
   }
 }
 
 ProgressBarStep.propTypes = {
-  step: PropTypes.object,
+  clickable: PropTypes.bool,
   navigateToPath: PropTypes.func,
+  step: PropTypes.object,
 };

--- a/src/molecules/StepIndicator/index.js
+++ b/src/molecules/StepIndicator/index.js
@@ -7,8 +7,9 @@ import styles from './step_indicator.module.scss';
 function StepIndicator(props) {
   const {
     className,
+    clickable,
+    navigateToPath,
     steps,
-    navigateToPath
   } = props;
 
   return (
@@ -19,6 +20,7 @@ function StepIndicator(props) {
             key={idx}
             step={step}
             navigateToPath={navigateToPath}
+            clickable={clickable}
           />
         )}
       </div>
@@ -50,7 +52,15 @@ StepIndicator.propTypes = {
   /**
    * Click handler for steps; expects to be called with path name
    */
-  navigateToPath: PropTypes.func.isRequired
+  navigateToPath: PropTypes.func,
+  /**
+   * Bool will determine whether any steps are clickable. Set to `false` for non-functional, presentation-only progress bars
+   */
+  clickable: PropTypes.bool
+};
+
+StepIndicator.defaultProps = {
+  clickable: true
 };
 
 export default StepIndicator;

--- a/src/molecules/StepIndicator/step_indicator.module.scss
+++ b/src/molecules/StepIndicator/step_indicator.module.scss
@@ -25,7 +25,7 @@
 .step-wrapper {
   text-align: center;
   width: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: rem-calc(16px);
 
   &-clickable {
     cursor: pointer;
@@ -40,7 +40,7 @@
 
   &:after {
     content: '';
-    height: .125rem;
+    height: rem-calc(2px);
     pointer-events: none;
     position: absolute;
     top: 4px;
@@ -85,6 +85,12 @@
   text-transform: uppercase;
 }
 
+.step-subtitle {
+  margin-top: rem-calc(32px);
+  padding: 0 rem-calc(16px);
+  text-align: center;
+}
+
 @media #{$small-only} {
   .step-wrapper {
     &-inactive {
@@ -94,5 +100,9 @@
 
   .circle-wrapper {
     margin-left: 40%;
+  }
+
+  .step-subtitle {
+    display: none;
   }
 }


### PR DESCRIPTION
- Adds `inert` prop to the StepIndicator to allow the creation of presentational, non-interactive step indicators.
- Allows for the addition of subtitles for each step

Corresponds to [CH21562](https://app.clubhouse.io/policygenius/story/21562/user-should-see-a-slimmed-full-app-including-exit-survey)

@jmcolella @Jexeones24