### PR TITLE
make numbered accordion list optional

### DIFF
--- a/src/organisms/Accordion/AccordionPanel/index.js
+++ b/src/organisms/Accordion/AccordionPanel/index.js
@@ -31,7 +31,8 @@ export default class AccordionPanel extends Component {
       title,
       type,
       closeText,
-      openText
+      openText,
+      disableNumberedList
     } = this.props;
 
     const sectionClasses = cx(styles['panel'], styles[type]);
@@ -46,9 +47,11 @@ export default class AccordionPanel extends Component {
           className={styles['header']}
           onClick={this.handleClick}
         >
-          <span className={styles['ordinal']}>
-            {number}.
-          </span>
+          { !disableNumberedList &&
+            <span className={styles['ordinal']}>
+              {number}.
+            </span>
+          }
           <Text
             className={styles['title']}
           >
@@ -81,7 +84,8 @@ AccordionPanel.propTypes = {
   openText: PropTypes.string,
   closeText: PropTypes.string,
   number: PropTypes.number,
-  type: PropTypes.oneOf([ 'basic' ])
+  type: PropTypes.oneOf([ 'basic' ]),
+  disableNumberedList: PropTypes.bool,
 };
 
 AccordionPanel.defaultProps = {

--- a/src/organisms/Accordion/index.js
+++ b/src/organisms/Accordion/index.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import styles from './accordion.module.scss';
 import AccordionPanel from './AccordionPanel';
 
-const sections = ({ panels, openText, closeText }) =>
+const sections = ({ panels, openText, closeText, disableNumberedList }) =>
   panels.map((panel, i) =>
     <AccordionPanel
       openText={openText}
@@ -12,6 +12,7 @@ const sections = ({ panels, openText, closeText }) =>
       key={i}
       open={i === 0}
       number={i + 1}
+      disableNumberedList={disableNumberedList}
       {...panel}
     />
   );
@@ -22,6 +23,7 @@ function Accordion(props) {
     closeText,
     panels,
     className,
+    disableNumberedList,
     } = props;
 
   const classes = cx(
@@ -36,7 +38,8 @@ function Accordion(props) {
       {sections({
         panels,
         openText,
-        closeText
+        closeText,
+        disableNumberedList
       })}
     </section>
   );
@@ -67,12 +70,17 @@ Accordion.propTypes = {
       title: PropTypes.string.isRequired,
       body: PropTypes.string.isRequired
     })
-  )
+  ),
+  /**
+   * Whether or not to number the accordion items. Defaults to `true`.
+   */
+  disableNumberedList: PropTypes.bool
 };
 
 Accordion.defaultProps = {
   openText: 'View',
-  closeText: 'Close'
+  closeText: 'Close',
+  disableNumberedList: false
 };
 
 export default Accordion;


### PR DESCRIPTION
one requirement of [this Accordion ticket](https://app.clubhouse.io/policygenius/story/21829/content-editors-can-create-accordion-sections) is that the numbers should not be hardcoded, so I've added in a prop to disable the numbered lists.

👀  please @sunnymis @jl08 