### PR TITLE
Update tooltip functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athenaeum",
-  "version": "8.14.1",
+  "version": "8.14.2",
   "description": "PolicyGenius React Component Library (RCL)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/atoms/Tooltip/__tests__/tooltip.spec.js
+++ b/src/atoms/Tooltip/__tests__/tooltip.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import Icon from 'atoms/Icon';
+import Modal from 'molecules/Modal';
+import Tooltip from '../';
+
+describe('Tooltip', () => {
+  let component;
+  let props;
+
+  it('defaults to Icon when text is not provided', () => {
+    component = mount(<Tooltip />);
+    const child = component.children().childAt(0);
+
+    expect(child.find(Icon).length).toEqual(1);
+  });
+
+  it('renders text when provided', () => {
+    props = { text: 'Hello world' };
+    component = mount(<Tooltip {...props} />);
+    const child = component.children().childAt(0);
+
+    expect(child.text()).toContain('Hello world');
+  });
+
+  describe('when the window is mobile size', () => {
+    it('should display children in a Modal', () => {
+      Object.defineProperty(global.window, 'innerWidth', { value: 500 });
+      props = { children: 'WAAAAAA' };
+      component = shallow(<Tooltip {...props} />);
+      expect(component.find(Modal).children().text()).toEqual('WAAAAAA');
+    });
+  });
+
+  describe('when the window is tablet or desktop size', () => {
+    const event = { stopPropagation: jest.fn() };
+    const handleClickMock = jest.fn();
+
+    beforeEach(() => {
+      Object.defineProperty(global.window, 'innerWidth', { value: 1100 });
+      props = { revealOnClick: true };
+    });
+
+    describe('and revealOnClick prop is present', () => {
+      it('should call handleClick() when clicked', () => {
+        component = mount(<Tooltip {...props} />);
+        component.instance().handleClick(event);
+
+        expect(component.state().modalIsOpen).toEqual(false);
+        expect(component.state().visible).toEqual(true);
+      });
+    });
+
+    describe('and revealOnClick prop is not present', () => {
+      it('should not call handleClick()', () => {
+        component = shallow(<Tooltip {...props} />);
+        component.setProps({ revealOnClick: false });
+        component.instance().handleClick(event);
+        expect(handleClickMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -10,24 +10,49 @@ class Tooltip extends React.Component {
     super(props);
 
     this.state = {
-      modalIsOpen: false
+      modalIsOpen: false,
+      visible: false
     };
-
-    this.openModal = this.openModal.bind(this);
-    this.closeModal = this.closeModal.bind(this);
   }
 
-  openModal() {
+  componentDidMount() {
+    document.addEventListener('mousedown', this.hide);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.hide);
+  }
+
+  setWrapperRef = (node) => {
+    this.ref = node;
+  }
+
+  openModal = () => {
     (window.innerWidth <= 768) && this.setState({
       modalIsOpen: true
     });
   }
 
-  closeModal() {
+  closeModal = () => {
     this.setState({
       modalIsOpen: false
     });
   }
+
+  toggleVisibility = (e) => {
+    e.stopPropagation();
+    this.setState({ visible: !this.state.visible });
+    this.props.onClick && this.props.onClick(e);
+  };
+
+  hide = (e) => {
+    if (this.ref && !this.ref.contains(e.target)) {
+      e.stopPropagation();
+      this.setState({ visible: false });
+    }
+  };
+
+  handleClick = e => window.innerWidth <= 768 ? this.openModal() : this.toggleVisibility(e);
 
   render() {
     const {
@@ -35,22 +60,24 @@ class Tooltip extends React.Component {
       className,
       left,
       right,
-      onClick,
       text,
       hoverMessageClassName,
       inline,
       tooltipIconSize,
+      revealOnClick
     } = this.props;
 
     return (
       <span>
         <span
-          onClick={onClick || this.openModal}
+          onClick={revealOnClick ? this.handleClick : this.openModal}
           className={classnames(
-            styles['tooltip-wrapper'],
+            !revealOnClick && styles['tooltip-wrapper'],
+            this.state.visible && styles.reveal,
             inline && styles[`inline-${inline}`],
             className
           )}
+          ref={this.setWrapperRef}
         >
           {
             text ||
@@ -129,6 +156,11 @@ Tooltip.propTypes = {
    * Changes height and width of default Tooltip icon. Provide a pixel amount as a number (without the units)
    */
   tooltipIconSize: PropTypes.number,
+
+  /**
+   * When viewport is not mobile and revealOnClick prop is present, reveals tooltip message on click only
+   */
+  revealOnClick: PropTypes.bool
 };
 
 Tooltip.defaultProps = {

--- a/src/atoms/Tooltip/tooltip.module.scss
+++ b/src/atoms/Tooltip/tooltip.module.scss
@@ -95,7 +95,19 @@ $hover-message-shift: calc(50% - 3.06rem);
         display: block;
         visibility: visible;
         opacity: 1;
+        overflow-wrap: break-word;
       }
+    }
+  }
+
+  .reveal {
+    position: relative;
+
+    .hover-message {
+      display: block;
+      visibility: visible;
+      opacity: 1;
+      overflow-wrap: break-word;
     }
   }
 }

--- a/src/molecules/formfields/DateField/index.js
+++ b/src/molecules/formfields/DateField/index.js
@@ -106,12 +106,10 @@ DateField.propTypes = {
    * Any children passed to DateField
    */
   children: PropTypes.node,
-
   /**
    * Applies a React ref to the wrapping node for this field
    */
   fieldRef: PropTypes.func,
-
   /**
    * Adds a tooltip to the label. Provide string for text to be placed inside tooltip popup
    */

--- a/src/utils/fieldUtils/__tests__/renderTooltip.spec.js
+++ b/src/utils/fieldUtils/__tests__/renderTooltip.spec.js
@@ -28,18 +28,6 @@ describe('renderTooltip()', () => {
         expect(modalElement.length).toEqual(1);
       });
     });
-
-    describe('tooltip is a function', () => {
-      it('returns Tooltip with tooltip argument as onClick', () => {
-        const tooltip = jest.fn();
-
-        const component = renderTooltip(tooltip, className, iconClassName);
-        const wrapper = mount(component);
-        const tooltipElement = wrapper.children().childAt(0);
-
-        expect(tooltipElement.props().onClick).toEqual(tooltip);
-      });
-    });
   });
 
   describe('Icon', () => {


### PR DESCRIPTION
[CH22026](https://app.clubhouse.io/policygenius/story/22026/chore-implement-athenaeum-tooltip-in-life-web)

- Borrows functionality used in LifeWeb `Tooltip` to reveal `hover message` contents onClick when `revealOnClick` prop is passed to tooltip, otherwise default behavior is to show message on hover when screen size is not mobile 

- Sets a reference to the node using `setWrapperRef`. Ref is then used to detect an outside click to close the tooltip.

- Gives `DateField` component ability to render a `Tooltip`

- Ran into a problem with `CheckBoxField` where upon selection, the checkmark was not showing. Refactored the label text from a `Text` component using `tag='span'` to a wrapper span with the appropriate classname and functionality to toggle text color and font-weight.

CR @danielnovograd @jmcolella @jdanz 