### PR TITLE
Tweak form fields for better use in smoke tests

### DIFF
--- a/src/molecules/formfields/GoogleAutoCompleteField/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/molecules/formfields/GoogleAutoCompleteField/__tests__/__snapshots__/index.spec.js.snap
@@ -13,7 +13,7 @@ exports[`<GoogleAutoCompleteField /> renders correctly 1`] = `
       >
         <label
           className="label"
-          htmlFor={undefined}
+          htmlFor="autocomplete"
         >
           Street address
         </label>

--- a/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
+++ b/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
@@ -13,9 +13,11 @@ exports[`<RadioGroup /> renders correctly 1`] = `
       <div
         className="label"
       >
-        <span>
+        <label
+          htmlFor={undefined}
+        >
           Test label
-        </span>
+        </label>
         <span>
           <span
             className="tooltip-wrapper tooltip"

--- a/src/molecules/formfields/RadioGroup/index.js
+++ b/src/molecules/formfields/RadioGroup/index.js
@@ -42,7 +42,7 @@ class RadioGroup extends React.Component {
         >
           <div className={styles['label-wrapper']}>
             <div className={styles['label']}>
-              <span>{label}</span>
+              <label htmlFor={input.name}>{label}</label>
               { tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon']) }
             </div>
 

--- a/src/molecules/formfields/SelectField/index.js
+++ b/src/molecules/formfields/SelectField/index.js
@@ -44,6 +44,7 @@ class SelectField extends React.Component {
       subLabel,
       noBaseStyle,
       fieldRef,
+      id,
     } = this.props;
 
     const classes = [
@@ -62,7 +63,7 @@ class SelectField extends React.Component {
       <div ref={fieldRef && fieldRef}>
         <div className={classnames(...classes)}>
           { label &&
-            <label className={styles['label']} htmlFor={forProp}>
+            <label className={styles['label']} htmlFor={id || forProp}>
               { label }
               { renderAdditionalInfo(onAdditionalInfoClick) }
               {
@@ -86,7 +87,7 @@ class SelectField extends React.Component {
             <div className={styles['select-wrapper']}>
               <select
                 className={styles['select']}
-                id={forProp}
+                id={id || forProp}
                 {...requiredAttr()}
                 {...(omit(input, 'onClick'))}
               >
@@ -192,6 +193,12 @@ SelectField.propTypes = {
    * Applies a React ref to the wrapping node for this field
    */
   fieldRef: PropTypes.func,
+
+  /**
+   * id added to the `input` node and used for the `for` HTML attribute on the associated `label`.
+   * This prop is required to ensure the `label` and `input` follow best HTML5 accessibility practices as well as for testing purposes
+   */
+  id: PropTypes.string.isRequired,
 };
 
 SelectField.defaultProps = {

--- a/src/molecules/formfields/TextAreaField/index.js
+++ b/src/molecules/formfields/TextAreaField/index.js
@@ -17,6 +17,7 @@ function TextAreaField(props) {
     meta,
     noBaseStyle,
     fieldRef,
+    id,
   } = props;
 
   const classes = [
@@ -32,13 +33,14 @@ function TextAreaField(props) {
     <div ref={fieldRef && fieldRef}>
       <div className={classnames(...classes)}>
         { label &&
-          <label className={styles['label']} htmlFor={htmlFor}>{ label }</label>
+          <label className={styles['label']} htmlFor={id || htmlFor}>{ label }</label>
         }
 
         <textarea
           className={styles['textarea']}
           placeholder={placeholder}
           rows={rows}
+          id={id}
           {...input}
         />
       </div>
@@ -98,6 +100,12 @@ TextAreaField.propTypes = {
    * Applies a React ref to the wrapping node for this field
    */
   fieldRef: PropTypes.func,
+
+  /**
+   * id added to the `input` node and used for the `for` HTML attribute on the associated `label`.
+   * This prop is required to ensure the `label` and `input` follow best HTML5 accessibility practices as well as for testing purposes
+   */
+  id: PropTypes.string.isRequired,
 };
 
 TextAreaField.defaultProps = {

--- a/src/molecules/formfields/TextField/index.js
+++ b/src/molecules/formfields/TextField/index.js
@@ -66,7 +66,7 @@ class TextField extends React.Component {
           { label &&
             <div className={classnames(styles['header'])}>
               <div className={styles['label-wrapper']}>
-                <label className={styles['label']} htmlFor={htmlFor}>{ label }</label>
+                <label className={styles['label']} htmlFor={id || htmlFor}>{ label }</label>
                 { secure && <Icon className={styles['icon-lock']} icon='lock' /> }
                 { tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon']) }
               </div>
@@ -132,7 +132,8 @@ TextField.propTypes = {
     PropTypes.object
   ]),
   /**
-   * `for` prop on label
+   * `for` prop on label.
+   * Please use the `id` prop instead
    */
   htmlFor: PropTypes.string,
 
@@ -182,9 +183,11 @@ TextField.propTypes = {
   secure: PropTypes.bool,
 
   /**
-   * id added to the `input` node
+   * id added to the `input` node and used for the `for` HTML attribute on the associated `label`.
+   * This prop is required to ensure the `label` and `input` follow best HTML5 accessibility practices as well as for testing purposes
    */
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
+
   /**
    * either a handler for clicking the tooltip, or text to go in the tooltip for the label
    */


### PR DESCRIPTION
@danielnovograd @Jexeones24 @jdanz FYI

- Allows for `id` to be used as both the `htmlFor` for a `label` and `id` for the corresponding `input` to make HTML5 accessibility more consistent
- Makes minor HTML tweaks to allow for easier smoke testing