### PR TITLE
Fix Tooltip component to properly use revealOnClick prop

### DIFF
--- a/src/molecules/formfields/TextField/index.js
+++ b/src/molecules/formfields/TextField/index.js
@@ -194,6 +194,7 @@ TextField.propTypes = {
   tooltip: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,
+    PropTypes.object
   ]),
   /**
    * either a handler for clicking the tooltip, or text to go in the tooltip for the input

--- a/src/utils/fieldUtils/renderTooltip.js
+++ b/src/utils/fieldUtils/renderTooltip.js
@@ -23,7 +23,7 @@ export default function renderTooltip(tooltip, className, iconClassName) {
   return (
     <Tooltip
       className={className}
-      onClick={tooltip}
+      revealOnClick={tooltip.revealOnClick}
       right
       text={
         <Icon
@@ -31,6 +31,8 @@ export default function renderTooltip(tooltip, className, iconClassName) {
           className={iconClassName}
         />
       }
-    />
+    >
+      { tooltip.children }
+    </Tooltip>
   );
 }


### PR DESCRIPTION
Found a bug when running though the `FullApplicationForm` in Life Web where the tooltips passed to `TextField` components were not rendering onClick. This was due to incorrectly passing `revealOnClick` and tooltip children to `renderTooltip` function used by TextField.

CR @danielnovograd @jmcolella @jdanz 

