### PR TITLE
Get short repo name; ignore .scannerwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tmp/
 
 # Temp svgs.txt file for updating the Icon prop types
 svgs.txt
+
+# Ignore sonar-scanner results folder
+.scannerwork/

--- a/bin/scan-pullrequest
+++ b/bin/scan-pullrequest
@@ -9,7 +9,9 @@ fi
 
 echo "Running automated code review with SonarQube..."
 
-SHORT_REPO_NAME=$(echo ${BUILDKITE_REPO} | sed 's/git@github\.com:\(.*\)\.git/\1/')
+SHORT_REPO_NAME=$(echo ${BUILDKITE_REPO} | \
+  sed 's/git@github\.com:\(.*\)/\1/' | \
+  sed 's/\(.*\)\.git/\1/')
 
 echo "BuildKite Pull Request: ${BUILDKITE_PULL_REQUEST}"
 echo "BuildKite Repo Name: ${SHORT_REPO_NAME}"


### PR DESCRIPTION
- Fix script to get short repo name
- Ignore .scannerwork folder