### PR TITLE
Update ToggleField propTypes

### DIFF
--- a/src/molecules/formfields/ToggleField/index.js
+++ b/src/molecules/formfields/ToggleField/index.js
@@ -143,7 +143,7 @@ ToggleField.propTypes = {
   tooltip: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.shape({
-      children: PropTypes.string.isRequired,
+      children: PropTypes.node.isRequired,
       className: PropTypes.string,
       styles: PropTypes.object
     })


### PR DESCRIPTION
- Updates ToggleField.props.children to be a node (string or React element)

@jmcolella @Jexeones24 @jdanz 