### PR TITLE
Update Tooltip onClick fallback

### DIFF
--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -27,10 +27,11 @@ class Tooltip extends React.Component {
     this.ref = node;
   }
 
-  openModal = () => {
+  openModal = (e) => {
     (window.innerWidth <= 768) && this.setState({
       modalIsOpen: true
     });
+    this.props.onClick && this.props.onClick(e, true);
   }
 
   closeModal = () => {
@@ -42,7 +43,7 @@ class Tooltip extends React.Component {
   toggleVisibility = (e) => {
     e.stopPropagation();
     this.setState({ visible: !this.state.visible });
-    this.props.onClick && this.props.onClick(e);
+    this.props.onClick && this.props.onClick(e, !this.state.visible);
   };
 
   hide = (e) => {
@@ -52,7 +53,7 @@ class Tooltip extends React.Component {
     }
   };
 
-  handleClick = e => window.innerWidth <= 768 ? this.openModal() : this.toggleVisibility(e);
+  handleClick = e => window.innerWidth <= 768 ? this.openModal(e) : this.toggleVisibility(e);
 
   render() {
     const {


### PR DESCRIPTION
@danielnovograd @Jexeones24 @jdanz @sunnymis CR please

Inspired by [CH 23691](https://app.clubhouse.io/policygenius/story/23691/pm-marketer-should-see-analytics-on-tooltip-onclick-events)

- Adds `props.onClick` fallback when `openModal` is fired for mobile tooltips
- Passes `visible` state and open modal status (`true`) to `props.onClick` to allow for fine tuning end user logic based on whether the tooltip is open or not