### PR TITLE
Update formfields font

### DIFF
--- a/src/molecules/formfields/shared/formfields.module.scss
+++ b/src/molecules/formfields/shared/formfields.module.scss
@@ -27,7 +27,7 @@ $field-error-color: color('primary-1');
 // -- Mixins
 @mixin placeholder() {
   &::placeholder {
-    color: color('neutral-3');
+    color: color('neutral-2');
     font-weight: 400;
   }
 }
@@ -42,7 +42,7 @@ $field-error-color: color('primary-1');
 }
 
 %field {
-  @include typography-b(8);
+  @include typography-b-7;
 
   padding: rem-calc(12px) rem-calc(18px);
   border: 0;


### PR DESCRIPTION
Updates `field` extension to use a base font size of `typography-b-7` as opposed to the smaller `typography-b-8`.  It seems there was a conflict between font sizing with different fields (`TextField` vs `SelectField`) so this update a) aligns all fields to have the same font and b) follows the precedent for field font size set in life-web.