### PR TITLE
Update sonar-scanner URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yarn --frozen-lockfile
 COPY . /app/
 
 RUN cd /opt \
-  && curl -o sonar-scanner.zip -fSL https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_CLI_VERSION-linux.zip \
+  && curl -o sonar-scanner.zip -fSL https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_CLI_VERSION-linux.zip \
   && unzip sonar-scanner.zip \
   && mv sonar-scanner-$SONAR_SCANNER_CLI_VERSION-linux sonar-scanner \
   && rm sonar-scanner.zip*


### PR DESCRIPTION
Existing URL breaks the builds since SonarQube is now hosting the zip file on their domain