### PR TITLE
Update Label Size on Mobile for RadioGroup

### DIFF
--- a/src/molecules/formfields/RadioGroup/radio_group.module.scss
+++ b/src/molecules/formfields/RadioGroup/radio_group.module.scss
@@ -11,7 +11,7 @@
 }
 
 .label {
-  @include typography-b-10(true);
+  @include typography-b-8(true);
 
   display: flex;
 }


### PR DESCRIPTION
The `RadioGroup` label on mobile should match the sizing of the
other components.