### PR TITLE
Bug - Wrong Date on FullDateField when 1st of Month

### DIFF
--- a/src/molecules/formfields/FullDateField/__tests__/full_date_field.spec.js
+++ b/src/molecules/formfields/FullDateField/__tests__/full_date_field.spec.js
@@ -187,6 +187,30 @@ describe('<FullDateField />', () => {
         expect(year.props().value).toEqual(DATE.getFullYear());
       });
     });
+
+    describe('when the valid date is the first of the month', () => {
+      beforeEach(() => {
+        props = {
+          ...props,
+          input: {
+            ...props.input,
+            value: '2018-01-01T00:00:00Z'
+          }
+        };
+
+        component = mount(<FullDateField {...props} />);
+      });
+
+      it('sets the month/year selects', () => {
+        const month = component.find('[name="aDateMonth"]');
+        const day = component.find('[name="aDateDay"]');
+        const year = component.find('[name="aDateYear"]');
+
+        expect(month.props().value).toEqual(1);
+        expect(day.props().value).toEqual(1);
+        expect(year.props().value).toEqual(2018);
+      });
+    });
   });
 
   describe('isValidDayInput', () => {

--- a/src/molecules/formfields/util/BaseDateField/index.js
+++ b/src/molecules/formfields/util/BaseDateField/index.js
@@ -21,7 +21,7 @@ class BaseDateField extends React.Component {
   constructor(props) {
     super(props);
 
-    const date = new Date(props.input.value);
+    const date = this.createDate(props.input.value);
 
     if (isValid(date)) {
       this.state = {
@@ -36,6 +36,17 @@ class BaseDateField extends React.Component {
         yearValue: ''
       };
     }
+  }
+
+  createDate = (date) => {
+    /* New dates are in UTC time and default to midnight if not specified.
+     * EST is behind UTC so it'll calculate the date as the previous date.
+     * We need to offset that time correctly assign the date.
+     * See https://stackoverflow.com/questions/45407072/javascript-dates-are-a-day-off
+     */
+    const utcDate = new Date(date);
+
+    return new Date(utcDate.getTime() + (utcDate.getTimezoneOffset() * 60000));
   }
 
   changeFullDate = (prevState) => {


### PR DESCRIPTION
The `FullDateField` was displaying the previous day when passed a date that was the first of the month. This has to do with how `new Date()`. works, it does some auto-adjusting behind the scenes. It is safer to pass the date values directly into the constructor i.e `new Date(2018, 10, 29)`