### PR TITLE
Update handleClickOutside function for BaseFieldGroup

### DIFF
--- a/src/molecules/formfields/util/BaseFieldGroup/index.js
+++ b/src/molecules/formfields/util/BaseFieldGroup/index.js
@@ -8,7 +8,7 @@ class BaseFieldGroup extends React.Component {
     meta: PropTypes.object,
   }
 
-  componentWillMount() {
+  componentDidMount() {
     document.addEventListener('click', this.handleClickOutside, false);
   }
 
@@ -21,10 +21,10 @@ class BaseFieldGroup extends React.Component {
   clickIsLeaving = true;
 
   handleClickOutside = (e) => {
-    const { input, meta: { touched } } = this.props;
+    const { input } = this.props;
 
     if (!this.wrapperReference) { return; }
-    if (touched && !this.wrapperReference.contains(e.target)) {
+    if (!this.wrapperReference.contains(e.target)) {
       input.onBlur();
     }
   }


### PR DESCRIPTION
@sunnymis CR please

- Updates `handleClickOutside` function for `BaseFieldGroup` to not use the `touched` property from Redux Form/Final Form. This value was not updating properly when used with Final Form and is not necessary for use with Redux Form (tested in the life flow).