### PR TITLE
Add headerText prop to ToolTip

### DIFF
--- a/src/atoms/Tooltip/__tests__/tooltip.spec.js
+++ b/src/atoms/Tooltip/__tests__/tooltip.spec.js
@@ -23,6 +23,24 @@ describe('Tooltip', () => {
     expect(child.text()).toContain('Hello world');
   });
 
+  describe('headerText', () => {
+    describe('when headerText is default', () => {
+      it('returns the default prop value', () => {
+        component = shallow(<Tooltip />);
+        expect(component.find(Modal).props().header).toEqual('Learn More');
+      });
+    });
+
+    describe('when headerText is provided', () => {
+      it('renders the provided headerText prop', () => {
+        const headerText = 'Fear is the mind-killer';
+        props = { headerText: headerText };
+        component = shallow(<Tooltip {...props}/>);
+        expect(component.find(Modal).props().header).toEqual(headerText);
+      });
+    });
+  });
+
   describe('when the window is mobile size', () => {
     it('should display children in a Modal', () => {
       Object.defineProperty(global.window, 'innerWidth', { value: 500 });

--- a/src/atoms/Tooltip/index.js
+++ b/src/atoms/Tooltip/index.js
@@ -59,13 +59,14 @@ class Tooltip extends React.Component {
     const {
       children,
       className,
-      left,
-      right,
-      text,
+      headerText,
       hoverMessageClassName,
       inline,
+      left,
+      revealOnClick,
+      right,
+      text,
       tooltipIconSize,
-      revealOnClick
     } = this.props;
 
     return (
@@ -102,7 +103,7 @@ class Tooltip extends React.Component {
           </span>
         </span>
         <Modal
-          header='Learn more'
+          header={headerText}
           onRequestClose={this.closeModal}
           isOpen={this.state.modalIsOpen}
           contentLabel=''
@@ -161,10 +162,16 @@ Tooltip.propTypes = {
   /**
    * When viewport is not mobile and revealOnClick prop is present, reveals tooltip message on click only
    */
-  revealOnClick: PropTypes.bool
+  revealOnClick: PropTypes.bool,
+
+  /**
+   * The text for the header of the Tooltip
+   */
+  headerText: PropTypes.string,
 };
 
 Tooltip.defaultProps = {
+  headerText: 'Learn More',
   tooltipIconSize: 12,
 };
 


### PR DESCRIPTION
Story: https://app.clubhouse.io/policygenius/story/24776/engineer-should-be-able-to-customize-tooltip-header

### Motivation
Some of our upcoming design changes require the ability to have different header tests for ToolTips. This PR adds a new `headerProp` with a default value of the legacy behavior. 