### PR TITLE
Add 100% height

### DIFF
--- a/src/organisms/Accordion/AccordionPanel/accordion_panel.module.scss
+++ b/src/organisms/Accordion/AccordionPanel/accordion_panel.module.scss
@@ -79,7 +79,7 @@
 }
 
 .content.content-open {
-  max-height: 1000px;
+  max-height: 100%;
   transition: max-height 1s ease-out,
               opacity 200ms ease-in;
   opacity: 1;


### PR DESCRIPTION
[CH-21802](https://app.clubhouse.io/policygenius/stories/space/21802/c3po-overview)

- Accordion Panel had a max height of 1000px which was cutting off longer content
- Added max-height of 100% to display everything 