### PR TITLE
Fix iOS bug where state is null for windowPosition

### DIFF
--- a/src/molecules/Modal/index.js
+++ b/src/molecules/Modal/index.js
@@ -12,6 +12,8 @@ import checkiOSDevice from './util/checkiOSDevice';
 
 class Modal extends React.Component {
 
+  state = { windowPosition: 0 };
+
   componentWillMount() {
     if (typeof document !== 'undefined') {
       ReactModal.setAppElement('body');


### PR DESCRIPTION
### Motivation
I introduced a bug where iOS devices would fail on modal close in this PR: https://github.com/policygenius/athenaeum/pull/743 because I removed the constructor, which also removed state initialization. This PR re-introduces the specific piece of state that iOS devices rely on. 

Follow-up should be to identify if we can simply remove ALL iOS-targeted logic from the Modal, especially the scroll behavior. 