### PR TITLE
Bump node base image to 8.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.3
+FROM node:8.15
 
 ENV SONAR_SCANNER_CLI_VERSION=3.2.0.1227 \
     SONAR_SCANNER_HOME=/opt/sonar-scanner

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   },
   "engines": {
     "yarn": "^1.3.2",
-    "node": ">=8.11.3"
+    "node": ">=8.15.1"
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
Unticketed work. 

There is a security issue with the version of node specified in the Dockerfile and the build process fails because of unavailable base image components: https://github.com/nodejs/docker-node/issues/1012

This PR bumps the version to 8.15. 