### PR TITLE
Bump node version to 8.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:8.11.3
-
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+FROM node:8.15.1
 
 ENV SONAR_SCANNER_CLI_VERSION=3.2.0.1227 \
     SONAR_SCANNER_HOME=/opt/sonar-scanner

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   },
   "engines": {
     "yarn": "^1.3.2",
-    "node": ">=8.11.3"
+    "node": ">=8.15.1"
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
Node version 8.11.3 was pointing to an endpoint to download Debian jessie that no longer existed, causing builds to fail. We put an undesirable patch in to help us get a deploy out, but this should be the proper fix.