### PR TITLE
Add calculatorGrey icon

### DIFF
--- a/src/atoms/Icon/constants.js
+++ b/src/atoms/Icon/constants.js
@@ -25,6 +25,7 @@ module.exports = {
     'bookSearch',
     'books',
     'calculator',
+    'calculatorGrey',
     'calculatorOrange',
     'calendar',
     'camera',


### PR DESCRIPTION
Story: https://app.clubhouse.io/policygenius/story/30929/user-should-see-calculator

Adds the `calculatorGrey` icon to the `Icon` constants file.