### PR TITLE
`a` tags should accept onclicks

### DIFF
--- a/src/atoms/Button/index.js
+++ b/src/atoms/Button/index.js
@@ -39,6 +39,7 @@ function Button( props ) {
         disabled={disabled}
         href={href}
         {...linkAttrs}
+        {...rest}
       >
         { icon && <Icon icon={icon} className={styles['icon']} /> }
         { children || text }


### PR DESCRIPTION
We encountered a bug, where onclick events were not always getting passed to our buttons.  So that our buttons don't always need to be in forms, we are just adding the rest of the props that we pass to buttons to our `a` buttons.