### PR TITLE
Add agent2 icon

### DIFF
--- a/src/atoms/Icon/constants.js
+++ b/src/atoms/Icon/constants.js
@@ -2,6 +2,7 @@ module.exports = {
   icons: [
     'addAccount',
     'agent',
+    'agent2',
     'americanExpress',
     'americanExpressSq',
     'americanExpressSquare',


### PR DESCRIPTION
We use this icon in Life-web, but it looks like it never got added to the constants file, resulting in a prop warning. This PR simply adds the missing value. 