### PR TITLE
re-add Checkbox field and checkbox wrapper

### DIFF
--- a/src/molecules/formfields/CheckBoxField/Readme.md
+++ b/src/molecules/formfields/CheckBoxField/Readme.md
@@ -1,0 +1,10 @@
+Checkbox Example:
+
+```jsx
+  <CheckBoxField
+    label='Fire extinguisher'
+    input={{
+      name: 'checkbox_test'
+    }}
+  />
+```

--- a/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
+++ b/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
@@ -1,0 +1,86 @@
+$size: ru(1);
+$gap: ru(.5);
+
+.checkbox {
+  display: flex;
+  align-content: center;
+  position: relative;
+  margin: 0;
+  min-height: $size;
+  padding-left: $size + $gap;
+  user-select: none;
+
+  + .checkbox {
+    margin-top: ru(.75);
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: $size;
+    height: $size;
+    border: 1px solid color('neutral-3');
+    background-color: color('primary-2');
+    overflow: hidden;
+    border-radius: 2px;
+  }
+}
+
+.checkbox-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: $size + $gap;
+  height: $size;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
+
+  &:checked {
+    + .checkbox-label:after { opacity: 1; }
+  }
+
+  &:disabled {
+    + .checkbox-label {
+      cursor: not-allowed;
+      color: color('neutral-3');
+    }
+
+    + .checkbox-label:after {
+      box-shadow: 3px 3px 0 0 color('secondary-2');
+    }
+  }
+}
+
+.checkbox-label {
+  cursor: pointer;
+}
+
+.checkbox-label:after {
+  $width: $size / 3;
+  $height: $size / 2;
+
+  position: absolute;
+  width: $width;
+  height: $height;
+  top: $width / 2;
+  left: $height / 2;
+  margin-left: rem-calc(1px);
+
+  transform: rotate(45deg);
+  transform-origin: right;
+  box-shadow: 3px 3px 0 0 color('secondary-2');
+  border-radius: 20%;
+
+  opacity: 0;
+  content: '';
+}
+
+@media #{$tablet} {
+  .checkbox {
+    line-height: ru(.75);
+    margin: 0;
+  }
+}

--- a/src/molecules/formfields/CheckBoxField/index.js
+++ b/src/molecules/formfields/CheckBoxField/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Text from 'atoms/Text';
+
+import styles from './checkbox_field.module.scss';
+
+class CheckBoxField extends React.Component {
+  render() {
+    const {
+      label,
+      input,
+      textColor,
+      fieldRef,
+    } = this.props;
+
+    return (
+      <label
+        className={styles['checkbox']}
+        htmlFor={`checkbox-${input.name}`}
+        ref={fieldRef && fieldRef}
+      >
+        <input
+          type='checkbox'
+          id={`checkbox-${input.name}`}
+          className={styles['checkbox-input']}
+          checked={input.value}
+          {...input}
+        />
+        <span className={styles['checkbox-label']}>
+          <Text
+            bold={input.checked}
+            color={input.checked ? 'primary-3' : textColor || 'neutral-2'}
+          >
+            { label }
+          </Text>
+        </span>
+      </label>
+    );
+  }
+}
+
+CheckBoxField.propTypes = {
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  /**
+   * The props under the meta key are metadata about the state of this field that `redux-form` tracks.
+   */
+  meta: PropTypes.object,
+  /**
+   * The props under the input key are passed from `redux-form` and spread into `<input />`.
+   */
+  input: PropTypes.object,
+
+  /**
+   * Makes field disabled
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * Applies color to label text; use Pg brand color names
+   */
+  textColor: PropTypes.string,
+
+  /**
+   * Applies a React ref to the wrapping node for this field
+   */
+  fieldRef: PropTypes.func,
+};
+
+export default CheckBoxField;

--- a/src/molecules/formfields/CheckboxWrapper/Readme.md
+++ b/src/molecules/formfields/CheckboxWrapper/Readme.md
@@ -1,0 +1,99 @@
+Checkbox List Example:
+
+```jsx
+  <CheckboxWrapper
+    label='Pellentesque habitant'
+    tooltip="I'm a tooltip!"
+    subLabel='Test sublabel'
+    input={{
+      onBlur: () => true,
+      onFocus: () => true,
+    }}
+    meta={{}}
+  >
+    <CheckBoxField
+      input={{
+        name: 'extinguisher'
+      }}
+      label='Fire extinguisher'
+    />
+    <CheckBoxField
+      input={{
+        name: 'localFireAlarm'
+      }}
+      label='Local fire/smoke alarm (sounds in home)'
+    />
+    <CheckBoxField
+      input={{
+        name: 'centralFireAlarm'
+      }}
+      label='Central fire/smoke alarm (alerts monitoring system)'
+    />
+    <CheckBoxField
+      input={{
+        name: 'automaticSprinklersAll'
+      }}
+      label='Automatic sprinklers in all rooms (including closets)'
+    />
+    <CheckBoxField
+      input={{
+        name: 'automaticSprinklersSome'
+      }}
+      label='Automatic sprinklers in some rooms'
+    />
+  </CheckboxWrapper>
+```
+
+Checkbox List w/Footer Example:
+
+```jsx
+  <CheckboxWrapper
+    label='Pellentesque habitant'
+    tooltip="I'm a tooltip!"
+    subLabel='Test sublabel'
+    footerBox={
+      <CheckBoxField
+        input={{
+          name: 'none',
+        }}
+        label='None of the above'
+      />
+    }
+    input={{
+      onBlur: () => true,
+      onFocus: () => true,
+    }}
+    meta={{}}
+  >
+    <CheckBoxField
+      input={{
+        name: 'burgers',
+      }}
+      label='Burgers'
+    />
+    <CheckBoxField
+      input={{
+        name: 'dogs',
+      }}
+      label='Hot Dogs'
+    />
+    <CheckBoxField
+      input={{
+        name: 'fries',
+      }}
+      label='French Fries'
+    />
+    <CheckBoxField
+      input={{
+        name: 'shake',
+      }}
+      label='Milkshake'
+    />
+    <CheckBoxField
+      input={{
+        name: 'pop',
+      }}
+      label='Soda Pop'
+    />
+  </CheckboxWrapper>
+```

--- a/src/molecules/formfields/CheckboxWrapper/checkbox_wrapper.module.scss
+++ b/src/molecules/formfields/CheckboxWrapper/checkbox_wrapper.module.scss
@@ -1,0 +1,66 @@
+@import '../shared/formfields.module.scss';
+
+.checkbox-list {
+  @extend %form-field;
+}
+
+.no-field-borders {
+  .checkbox {
+    border: 0;
+  }
+}
+
+.header {
+  padding: ru(.5) ru(1);
+  border-bottom: 1px solid color('neutral-4');
+}
+
+.label-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label {
+  @extend %label;
+  padding: 0;
+}
+
+.tooltip {
+  margin-left: auto;
+}
+
+.tooltip-icon {
+  @extend %tooltip-icon;
+}
+
+.checkbox {
+  padding: rem-calc(12px) rem-calc(24px);
+  border-bottom: 1px solid color('neutral-4');
+
+  &:last-child {
+    border: 0;
+  }
+}
+
+.footer-box {
+  padding: rem-calc(12px) rem-calc(24px);
+  border-top: 1px solid color('neutral-4');
+}
+
+/* --  state:focus  -- */
+.focused {
+  border: 1px solid color('secondary-2');
+}
+
+/* --  state:error  -- */
+.hasError {
+  border: 1px solid color('primary-1');
+}
+
+@media #{$tablet} {
+  .checkbox {
+    border: 0;
+    padding-right: 0;
+  }
+}

--- a/src/molecules/formfields/CheckboxWrapper/index.js
+++ b/src/molecules/formfields/CheckboxWrapper/index.js
@@ -1,0 +1,165 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import ErrorMessage from 'atoms/ErrorMessage';
+import Layout from 'atoms/Layout';
+import Col from 'atoms/Layout/Col';
+import Text from 'atoms/Text';
+import { renderTooltip } from 'utils/fieldUtils';
+
+import styles from './checkbox_wrapper.module.scss';
+import BaseFieldGroup from '../util/BaseFieldGroup';
+
+class CheckboxWrapper extends BaseFieldGroup {
+  get childCols() {
+    const { children } = this.props;
+
+    const numberOfChildren = React.Children.toArray(children).length;
+
+    const cols = {
+      smallCols: [ 12 ],
+    };
+
+    if (numberOfChildren > 1) {
+      cols.mediumCols = [ 6 ];
+    }
+
+    return cols;
+  }
+
+  render() {
+    const {
+      label,
+      children,
+      tooltip,
+      subLabel,
+      footerBox,
+      meta,
+      input,
+      className,
+      fieldRef,
+      noFieldBorders,
+    } = this.props;
+
+    const showErrorMessage = !meta.active && (meta.visited || meta.submitFailed);
+    const message = meta && showErrorMessage && (meta.error || meta.warning);
+
+    const classes = [
+      styles['checkbox-list'],
+      meta && meta.active && styles['focused'],
+      meta && showErrorMessage && meta.error && !meta.active && styles['hasError'],
+      noFieldBorders && styles['no-field-borders'],
+      className,
+    ];
+
+    return (
+      <div
+        ref={(ref) => {
+          this.wrapperReference = ref;
+          fieldRef;
+        }}
+      >
+        <div
+          className={classnames(...classes)}
+          onMouseDown={this.handleMouseDown}
+          onMouseUp={this.handleMouseUp}
+          onFocus={input && input.onFocus}
+        >
+          <div className={styles['header']}>
+            <div className={styles['label-wrapper']}>
+              { label && <label htmlFor='checkbox' className={styles['label']}>{label}</label> }
+              { tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon']) }
+            </div>
+
+            {
+              subLabel &&
+                <Text
+                  size={10}
+                  font='b'
+                >
+                  {subLabel}
+                </Text>
+            }
+          </div>
+          <Layout
+            {...this.childCols}
+            fullwidth
+            className={styles.content}
+          >
+            {
+              React.Children.map(children, child =>
+                <Col className={styles.checkbox}>
+                  {
+                    React.cloneElement(child, {
+                      ...child.props,
+                      onBlur: this.handleBlur,
+                    })
+                  }
+                </Col>
+              )
+            }
+          </Layout>
+
+          {
+            footerBox &&
+              <div className={styles['footer-box']}>
+                {
+                  React.cloneElement(footerBox, {
+                    ...footerBox.props,
+                    onBlur: this.handleBlur,
+                  })
+                }
+              </div>
+          }
+        </div>
+        <ErrorMessage
+          condition={!!message}
+          message={message}
+        />
+      </div>
+    );
+  }
+}
+
+CheckboxWrapper.propTypes = {
+  /**
+   * This prop will add a new className to any inherent classNames
+   * provided in the component's index.js file.
+   */
+  className: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+
+  /**
+   * Text to appear directly under the label
+   */
+  subLabel: PropTypes.string,
+
+  /**
+   * CheckBox component to be placed at very bottom of Wrapper
+   */
+  footerBox: PropTypes.node,
+
+  /**
+   * ReduxForm meta props
+   */
+  meta: PropTypes.object,
+
+  /**
+   * ReduxForm input props
+   */
+  input: PropTypes.object,
+
+  /**
+   * Adds tooltip to wrapper
+   */
+  tooltip: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
+};
+
+export default CheckboxWrapper;

--- a/src/molecules/formfields/util/BaseFieldGroup/index.js
+++ b/src/molecules/formfields/util/BaseFieldGroup/index.js
@@ -1,0 +1,55 @@
+/* eslint-disable react/require-render-return */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class BaseFieldGroup extends React.Component {
+  static propTypes = {
+    input: PropTypes.object,
+    meta: PropTypes.object,
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleClickOutside, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClickOutside, false);
+  }
+
+  wrapperReference = null;
+
+  clickIsLeaving = true;
+
+  handleClickOutside = (e) => {
+    const { input } = this.props;
+
+    if (!this.wrapperReference) { return; }
+    if (!this.wrapperReference.contains(e.target)) {
+      input.onBlur();
+    }
+  }
+
+  handleMouseDown = (e) => {
+    if (this.wrapperReference.contains(e.currentTarget)) {
+      this.clickIsLeaving = false;
+    }
+  }
+
+  handleMouseUp = () => {
+    this.clickIsLeaving = true;
+  }
+
+  handleBlur = () => {
+    const { input } = this.props;
+
+    if (this.clickIsLeaving) {
+      input.onBlur();
+    }
+  }
+
+  render() {
+    throw Error('Child element should have its own call to .render');
+  }
+}
+
+export default BaseFieldGroup;


### PR DESCRIPTION
**Purpose**
Need to use `CheckboxWrapper` and `CheckBoxField` components for a feature in `pg-gatsby` 
Instead of copying this code over to use in `pg-gatsby` only, thought it would be better to just re-add it to this slimmed down version of `athenaeum`

**Fix**
- Add the `CheckboxWrapper` and `CheckBoxField` ( why is the casing inconsistent.. -.- ) that exists on master to this branch

@gummoe @jdanz @maxnovak @antciccone 