### PR TITLE
Update list

### DIFF
--- a/src/atoms/List/index.js
+++ b/src/atoms/List/index.js
@@ -101,7 +101,7 @@ List.propTypes = {
    * Makes the list horizontal and adds additional props
    */
   horizontal: PropTypes.shape({
-    spaceBetween: PropTypes.oneOf([ 6, 12, 18, 24, 36 ]),
+    spaceBetween: PropTypes.oneOf([ 6, 12, 13, 18, 24, 36 ]),
   }),
   /**
    * Adds bottomSpacing to each child `li`. See `Spacer` for size details


### PR DESCRIPTION
## Description 
- Add 13 to the proptypes in `List`
## Motivation 
```
    Warning: Failed prop type: Invalid prop `horizontal.spaceBetween` of value `13` supplied to `List`, expected one of [6,12,18,24,36].
```
- Content team is trying to get rid of warnings in the console and when running their tests