### PR TITLE
CH 35132 Icons from Athenaeum should load correctly when styled

### DIFF
--- a/src/atoms/Icon/index.js
+++ b/src/atoms/Icon/index.js
@@ -21,17 +21,24 @@ class Icon extends React.Component {
     const { renderSVGDOM, icon } = this.props;
 
     if (renderSVGDOM && icon) {
-      this.getSVG();
+      this.getSVG(5);
     }
   }
 
-  getSVG = () => {
-    fetch(this.svgSrc)
-      .then(data => data.text())
+  getSVG = async (count, option) => {
+    await fetch(this.svgSrc, option)
+      .then((data) => data.text())
       .then((svg) => {
         this.setState({
           svgString: svg,
         });
+      })
+      .catch((error) => {
+        if (count === 1) {
+          throw error;
+        }
+
+        return setTimeout(() => this.getSVG(count - 1, { cache: 'no-cache' }), 1000);
       });
   }
 


### PR DESCRIPTION
## Description
This changes how we request svgs and adds a few retries.  We also ignore cache if we need to retry, because occasionally we were seeing the failures being cached by the google bucket.

## Background & Context
We were occasionally seeing `renderSVGDOM` fail and icons being returned as images rather than raw svg.  The errors appeared to be coming from the bucket occationally returning a response of `"NetworkError when attempting to fetch resource."`