### PR TITLE
CH-35132 Remove async/await

### DIFF
--- a/src/atoms/Icon/index.js
+++ b/src/atoms/Icon/index.js
@@ -25,9 +25,9 @@ class Icon extends React.Component {
     }
   }
 
-  getSVG = async (count, option) => {
-    await fetch(this.svgSrc, option)
-      .then((data) => data.text())
+  getSVG = (count, option) => {
+    fetch(this.svgSrc, option)
+      .then(data => data.text())
       .then((svg) => {
         this.setState({
           svgString: svg,


### PR DESCRIPTION
[CH-35132](https://app.clubhouse.io/policygenius/story/35132/icons-from-athenaeum-should-load-correctly-when-styled)

Adding async await was causing issue on gatsby's build/with some of the plugins we use.  It isn't necessary so just removing it.