### PR TITLE
Only use lcov.info for SonarQube; Remove submodule dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "submodules/sonar_js_generic_coverage"]
-	path = submodules/sonar_js_generic_coverage
-	url = git@github.com:policygenius/sonar_js_generic_coverage.git
-	branch = master

--- a/bin/sonar
+++ b/bin/sonar
@@ -2,6 +2,4 @@
 
 buildkite-agent artifact download coverage/lcov.info coverage/ --build ${BUILDKITE_BUILD_ID}
 
-/usr/bin/python submodules/sonar_js_generic_coverage/sonar_js_generic_coverage.py coverage/
-
 sonar-scanner

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,5 +9,4 @@ sonar.tests=.
 sonar.test.inclusions=**/*.spec.js,**/*.spec.jsx,**/*.test.js,**/*.test.jsx
 sonar.login=${env.SONAR_LOGIN}
 sonar.host.url=https://sonar.policygenius.com
-sonar.coverageReportPaths=coverage/test-coverage.xml
 sonar.javascript.lcov.reportPath=coverage/lcov.info


### PR DESCRIPTION
For JS test coverage reports, we only need to use the `lcov.info` file generated by Jest. We no longer need to create a generic test coverage report for SonarQube as it can ingest the `lcov.info` file directly.

This PR removes the dependency of the submodule `sonar_js_generic_coverage` and the `test-coverage.xml` file it generates.

Once the dependency is removed, the `sonar_js_generic_coverage` repo can be archived.