### PR TITLE
add email gray icon

### DIFF
--- a/src/atoms/Icon/constants.js
+++ b/src/atoms/Icon/constants.js
@@ -85,6 +85,7 @@ module.exports = {
     'email',
     'emailCircle',
     'emailColor',
+    'emailGray',
     'emailLock',
     'excellentFace',
     'excellentFaceGreen',


### PR DESCRIPTION
**Purpose**
- `coverage-calculator` needs a gray email icon

**Steps**
- add gray email icon

@gummoe @jdanz @whitneychoo 
