### PR TITLE
WINNE-129: Handling "invalid" street addresses

### DIFF
--- a/src/molecules/formfields/GoogleAutoCompleteField/__tests__/index.spec.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/__tests__/index.spec.js
@@ -144,9 +144,11 @@ describe('<GoogleAutoCompleteField />', () => {
 
       it('should only extract the first digits as the street_number', () => {
         const streetNumber = 12;
-        const id = 'autocomplete-id';
-        const input = { name: 'address', value: `${streetNumber} W 50th St` };
-        const props = { ...baseProps, id, input };
+        const props = {
+          ...baseProps,
+          id: 'autocomplete-id',
+          input: { name: 'address', value: `${streetNumber} W 50th St` }
+        };
         const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
 
         wrapper.setState(state);
@@ -159,9 +161,11 @@ describe('<GoogleAutoCompleteField />', () => {
       });
 
       it('should not return a street_number, if extraction fails', () => {
-        const id = 'autocomplete-id';
-        const input = { name: 'address', value: 'Twelve Broadway' };
-        const props = { id, input, ...baseProps };
+        const props = {
+          ...baseProps,
+          id: 'autocomplete-id',
+          input: { name: 'address', value: 'Twelve Broadway' },
+        };
         const wrapper = shallow(<GoogleAutoCompleteField {...props} />);
 
         wrapper.setState(state);

--- a/src/molecules/formfields/GoogleAutoCompleteField/index.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/index.js
@@ -51,6 +51,18 @@ class GoogleAutoCompleteField extends Component {
   updateAddress = () => {
     const place = this.state.autocomplete.getPlace();
     const addressData = this.formatAddressInfo(place.address_components);
+
+    if (!addressData.number) {
+      const { value } = this.props.input;
+      const matches = value && value.match(/^(\d+)/);
+
+      if (matches && matches[0]) {
+        const number = parseInt(matches[0], 10);
+
+        addressData.number = { shortName: number, longName: number };
+      }
+    }
+
     const data = this.pickData(addressData);
 
     this.props.autocompleteAddressFields(data);
@@ -119,6 +131,7 @@ GoogleAutoCompleteField.propTypes = {
    */
   input: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    value: PropTypes.string,
   }).isRequired,
 
   /**

--- a/src/molecules/formfields/GoogleAutoCompleteField/index.js
+++ b/src/molecules/formfields/GoogleAutoCompleteField/index.js
@@ -54,10 +54,10 @@ class GoogleAutoCompleteField extends Component {
 
     if (!addressData.number) {
       const { value } = this.props.input;
-      const matches = value && value.match(/^(\d+)/);
+      const streetNumberMatch = value && value.match(/^(\d+)/);
 
-      if (matches && matches[0]) {
-        const number = parseInt(matches[0], 10);
+      if (streetNumberMatch && streetNumberMatch[0]) {
+        const number = parseInt(streetNumberMatch[0], 10);
 
         addressData.number = { shortName: number, longName: number };
       }


### PR DESCRIPTION
  - There are some street addresses that google doesn't recognize, and therefore does not return the street_number for
    - See this for more info: https://stackoverflow.com/a/48545776
  - In these cases, attempt to extract the street number from the user-input value, assuming the street number will be the number at the start of their input. If such an assumption is invalid, return no street number