### PR TITLE
Norton should not be on our footer anymore

### DIFF
--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -208,7 +208,6 @@ function Footer(props) {
         >
           <div className={styles['trust-logos']}>
             <Icon className={classnames(styles['trust-logo'], styles['logo-bbb'])} icon='bbb' />
-            <Icon className={classnames(styles['trust-logo'], styles['logo-norton'])} icon='norton' />
           </div>
 
           <Spacer size={6} />


### PR DESCRIPTION
We don't use Norton for security anymore and we should not be showing incorrect information in our footer.  We had removed this from our footer in all of our content, but our flows still show it.