### PR TITLE
Fixing signatures for BaseDateField field renderer functions

### DIFF
--- a/src/molecules/formfields/util/BaseDateField/index.js
+++ b/src/molecules/formfields/util/BaseDateField/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 
 import isValid from 'date-fns/is_valid';
 import inRange from 'lodash/inRange';
-import omit from 'lodash/omit';
 import get from 'lodash/get';
 
 import ErrorMessage from 'atoms/ErrorMessage';
@@ -172,7 +171,7 @@ class BaseDateField extends React.Component {
   get monthField() {
     const { input: dateFieldInput } = this.props;
 
-    return (props = { input: {} }) =>
+    return ({ input = {}, ...props } = {}) =>
       this.wrapChild(
         <TextField
           type='text'
@@ -185,16 +184,16 @@ class BaseDateField extends React.Component {
             maxLength: 2,
             noValidate: true,
             onChange: (e) => {
-              props.input.onChange && props.input.onChange(e);
+              input.onChange && input.onChange(e);
               this.month = e.target.value;
             },
             onFocus: dateFieldInput.onFocus,
             onBlur: this.blurIfLeaving,
             pattern: '[0-9]*',
             value: this.state.monthValue,
-            ...props.input,
+            ...input,
           }}
-          {...omit(props, 'input')}
+          {...props}
         />
       )
     ;
@@ -203,7 +202,7 @@ class BaseDateField extends React.Component {
   get dayField() {
     const { input: dateFieldInput } = this.props;
 
-    return (props = { input: {} }) =>
+    return ({ input = {}, ...props } = {}) =>
       this.wrapChild(
         <TextField
           type='text'
@@ -216,16 +215,16 @@ class BaseDateField extends React.Component {
             maxLength: 2,
             noValidate: true,
             onChange: (e) => {
-              props.input.onChange && props.input.onChange(e);
+              input.onChange && input.onChange(e);
               this.day = e.target.value;
             },
             onFocus: dateFieldInput.onFocus,
             onBlur: this.blurIfLeaving,
             pattern: '[0-9]*',
             value: this.state.dayValue,
-            ...props.input,
+            ...input,
           }}
-          {...omit(props, 'input')}
+          {...props}
         />
       )
     ;
@@ -234,7 +233,7 @@ class BaseDateField extends React.Component {
   get yearField() {
     const { input: dateFieldInput } = this.props;
 
-    return (props = { input: {} }) =>
+    return ({ input = {}, ...props } = {}) =>
       this.wrapChild(
         <TextField
           type='text'
@@ -247,16 +246,16 @@ class BaseDateField extends React.Component {
             maxLength: 4,
             noValidate: true,
             onChange: (e) => {
-              props.input.onChange && props.input.onChange(e);
+              input.onChange && input.onChange(e);
               this.year = e.target.value;
             },
             onFocus: dateFieldInput.onFocus,
             onBlur: this.blurIfLeaving,
             pattern: '[0-9]*',
             value: this.state.yearValue,
-            ...props.input,
+            ...input,
           }}
-          {...omit(props, 'input')}
+          {...props}
         />
       )
     ;


### PR DESCRIPTION
Fixing the arguments for the `dayField`, `monthField`, and `yearField` functions
  - The current returned functions provide a default value for their expected `input` prop when _no_ parameter is passed, but require that the `input` prop be passed explicitly when a parameter is passed
  - This fixes that, and allows props (eg. `{ placeholder: 'something' }`) to be passed down to the underlying `<TextField>` components without having to also supply an object for the `input` prop

For context: see [this PR comment](https://github.com/policygenius/winnebago/pull/444#discussion_r347646275), in relation to [this line of code in winnebago](https://github.com/policygenius/winnebago/blob/f8723b48e7d70fa051fb542389e98aa5bb0ff517/src/app/forms/Inputs/FullDateField/FullDateFieldComponent.tsx#L11)