### PR TITLE
Add gatsby stars

### DIFF
--- a/src/organisms/cards/CompanyCard/index.js
+++ b/src/organisms/cards/CompanyCard/index.js
@@ -15,7 +15,8 @@ const CompanyCard = (props) => {
     linkUrl,
     linkText,
     className,
-    variant
+    variant,
+    gatsbyStars,
   } = props;
 
   const classes = cx(
@@ -49,6 +50,7 @@ const CompanyCard = (props) => {
         <img className={styles.image} src={imageAttr.src} role='presentation' />
       </div>
       { starRating && <StarRating className={styles['star-rating']} rating={starRating} size={size} /> }
+      { !!gatsbyStars && gatsbyStars }
       { linkUrl && <ReadLink linkUrl={linkUrl} /> }
     </LinkWrapper>
   );
@@ -94,6 +96,12 @@ CompanyCard.propTypes = {
    * Possible card sizes are: 'large' or 'small'
   **/
   variant: PropTypes.string,
+  /**
+   * Can pass in react component
+  **/
+  gatsbyStars: PropTypes.element,
+
+
 };
 
 CompanyCard.defaultProps = {


### PR DESCRIPTION
## Description
<!--- Include a ticket link in this format: [CON <ticket_number>](<url_to_ticket>)-->
<!--- Describe your changes in detail -->
[CON-160](https://policygenius.atlassian.net/browse/CON-160)
- Add a `gatsbyStars` prop which can now take in a react element. Example from gatsby code below
```
<CompanyCard
    gatsbyStars={<StarRating  rating={rating}/>} // StarRating component lives in gatsby
 />
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Currently `CompanyCard` could not display a "half star" rating. 
- With the new "reviews" a company card needs to have the ability to render half stars. 
- The gatsby repo has its own star rating component that can display half stars 
- We wanted to utilize the already built half stars in gatsby with the already build `ComapanyCard` in athenaeum 


## Type of Change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Tech Debt (Clean up of code without changing anything directly)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
