### PR TITLE
Read in report files for PR analysis step

### DIFF
--- a/bin/scan-pullrequest
+++ b/bin/scan-pullrequest
@@ -7,6 +7,8 @@ then
   exit 0
 fi
 
+buildkite-agent artifact download coverage/lcov.info coverage/ --build ${BUILDKITE_BUILD_ID}
+
 echo
 echo "Running automated code review with SonarQube..."
 echo


### PR DESCRIPTION
# Description
[SRE-248](https://policygenius.atlassian.net/browse/SRE-248)

Since the SonarQube upgrade provides test coverage percentage for pull requests, the generated test result files are needed for analysis. This means the following:

- The `automated code review` step depends on the test steps running to completion since it now needs the test report file(s). This requires the `wait` step to be added prior.
- The `bin/scan-pullrequest` script now needs to retrieve the test result artifact file(s) to analyze.

# Motivation/Context
Previously, the `automated code review` step did not need the test result files since test code coverage analysis was not being performed. The issue surfaced when testing the feature and `0%` test coverage for pull requests were being captured for all updated repos.