### PR TITLE
Resolve serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.24.1",
     "chai": "^3.5.0",
-    "compression-webpack-plugin": "^1.0.0",
     "css-loader": "^0.28.0",
     "cssnano": "^3.10.0",
     "enzyme": "^3.0.0",
@@ -171,5 +170,8 @@
       "\\.(svg)$": "<rootDir>/src/utils/fileMock.js",
       "\\.(css|less|scss)$": "identity-obj-proxy"
     }
+  },
+  "resolutions": {
+    "serialize-javascript": "^2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@ async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.1.5, async@^2.4.1:
+async@^2.1.2, async@^2.1.4, async@^2.1.5:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -2089,16 +2089,6 @@ compressible@~2.0.13:
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
   dependencies:
     mime-db ">= 1.33.0 < 2"
-
-compression-webpack-plugin@^1.0.0:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-1.1.7.tgz#b0dfb97cf1d26baab997b584b8c36fe91872abe2"
-  dependencies:
-    async "^2.4.1"
-    cacache "^10.0.1"
-    find-cache-dir "^1.0.0"
-    serialize-javascript "^1.4.0"
-    webpack-sources "^1.0.1"
 
 compression@^1.5.2:
   version "1.7.2"
@@ -9331,9 +9321,10 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-serialize-javascript@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
+serialize-javascript@^1.4.0, serialize-javascript@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@^1.7.2:
   version "1.9.1"


### PR DESCRIPTION
- Security alert on [serialize-javascript](https://github.com/policygenius/athenaeum/network/alert/yarn.lock/serialize-javascript/open)

- Dependency of `compression-webpack-plugin` => ` compression-webpack-plugin` removed

- Dependency tree leads to `react-styleguidist` so can't upgrade `serialize-javascript` => resolved to `2.1.1`