### PR TITLE
Remove sinon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.3",
     "shelljs": "^0.7.7",
-    "sinon": "^2.1.0",
     "style-loader": "^0.16.1",
     "stylelint": "^7.10.1",
     "stylelint-declaration-strict-value": "^1.0.3",

--- a/plop_templates/test_template.txt
+++ b/plop_templates/test_template.txt
@@ -1,5 +1,4 @@
 import React from 'react';
-//import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
 

--- a/src/atoms/Button/__tests__/button.spec.js
+++ b/src/atoms/Button/__tests__/button.spec.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import assign from 'lodash/assign';
-import { expect } from 'chai';
 
 import Icon from 'atoms/Icon';
 import Button from '../index';
@@ -12,7 +10,7 @@ describe('Button', () => {
 
   beforeEach(() => {
     defaultProps = {
-      onClick: sinon.spy(),
+      onClick: jest.fn(),
       shake: false,
       type: 'button',
       disabled: false
@@ -22,29 +20,29 @@ describe('Button', () => {
   it('is a <button> tag', () => {
     const wrapper = shallow(<Button />);
 
-    expect(wrapper.type()).to.equal('button');
+    expect(wrapper.type()).toEqual('button');
   });
 
   it('adds the variant prop as a className', () => {
     const props = assign({}, defaultProps, { variant: 'info' });
     const wrapper = shallow(<Button {...props} />);
 
-    expect(wrapper.hasClass(props.variant)).to.be.true;
+    expect(wrapper.hasClass(props.variant)).toBe(true);
   });
 
   it('adds a custom className to button if given in props', () => {
     const props = assign({}, defaultProps, { className: 'customClass' });
     const wrapper = shallow(<Button {...props} />);
 
-    expect(wrapper.hasClass(props.className)).to.be.true;
+    expect(wrapper.hasClass(props.className)).toBe(true);
   });
 
   it('passes button attributes to button if given in props', () => {
     const props = assign({}, defaultProps, { disabled: false, type: 'reset' });
     const wrapper = shallow(<Button {...props} />);
 
-    expect(wrapper.prop('disabled')).to.equal(props.disabled);
-    expect(wrapper.prop('type')).to.equal(props.type);
+    expect(wrapper.prop('disabled')).toEqual(props.disabled);
+    expect(wrapper.prop('type')).toEqual(props.type);
   });
 
   it('renders the children correctly', () => {
@@ -53,15 +51,15 @@ describe('Button', () => {
         {'hello world!'}
       </Button>);
 
-    expect(wrapper.contains('hello world!')).to.be.true;
-    expect(wrapper.find(Icon)).to.have.length(1);
-    expect(wrapper.find(Icon).prop('icon')).to.equal('lock');
+    expect(wrapper.contains('hello world!')).toBe(true);
+    expect(wrapper.find(Icon).length).toEqual(1);
+    expect(wrapper.find(Icon).prop('icon')).toEqual('lock');
   });
 
   it('triggers props.onClick when clicked', () => {
     const wrapper = shallow(<Button {...defaultProps} />);
 
     wrapper.find('button').simulate('click');
-    expect(defaultProps.onClick.calledOnce).to.be.true;
+    expect(defaultProps.onClick).toHaveBeenCalled();
   });
 });

--- a/src/molecules/Modal/__tests__/modal.spec.js
+++ b/src/molecules/Modal/__tests__/modal.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
@@ -7,7 +6,7 @@ import Modal from 'molecules/Modal';
 
 describe('<Modal />', () => {
   let wrapper;
-  const callback = sinon.spy();
+  const callback = jest.fn();
 
   beforeEach(() => {
     wrapper = shallow(<Modal contentLabel='Test Modal' />);
@@ -39,7 +38,7 @@ describe('<Modal />', () => {
 
     wrapper.instance().onAfterOpen();
 
-    expect(callback.called).to.equal(true);
+    expect(callback.mock.calls).to.exist;
   });
 
   it('calls props.onRequestClose in this.onRequestClose', () => {
@@ -52,7 +51,7 @@ describe('<Modal />', () => {
 
     wrapper.instance().onRequestClose();
 
-    expect(callback.called).to.equal(true);
+    expect(callback.mock.calls).to.exist;
   });
 
   it('sets additional className prop', () => {
@@ -70,6 +69,6 @@ describe('<Modal />', () => {
 
     wrapper.find('.close').simulate('click');
 
-    expect(callback.called).to.equal(true);
+    expect(callback.mock.calls).to.exist;
   });
 });

--- a/src/organisms/Accordion/AccordionPanel/__tests__/accordion_panel.spec.js
+++ b/src/organisms/Accordion/AccordionPanel/__tests__/accordion_panel.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import sinon from 'sinon';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 

--- a/src/organisms/Accordion/__tests__/accordion.spec.js
+++ b/src/organisms/Accordion/__tests__/accordion.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import sinon from 'sinon';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 

--- a/src/organisms/cards/PartnerCard/__tests__/partner_card.spec.js
+++ b/src/organisms/cards/PartnerCard/__tests__/partner_card.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import sinon from 'sinon';
 import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 

--- a/src/organisms/cards/PlaybackCardWrapper/__tests__/playback_card_wrapper.spec.js
+++ b/src/organisms/cards/PlaybackCardWrapper/__tests__/playback_card_wrapper.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,11 +1799,6 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
-chownr@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
-  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
-
 ci-info@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
@@ -2735,10 +2730,6 @@ detective@^5.0.2:
     "@browserify/acorn5-object-spread" "^5.0.1"
     acorn "^5.2.1"
     defined "^1.0.0"
-
-diff@^3.1.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 diff@^3.2.0:
   version "3.5.0"
@@ -3848,12 +3839,6 @@ format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
 
-formatio@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
-
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -3882,13 +3867,6 @@ fs-extra@^3.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
     universalify "^0.1.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -6154,10 +6132,6 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
-lolex@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
-
 longest-streak@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-1.0.0.tgz#d06597c4d4c31b52ccb1f5d8f8fe7148eafd6965"
@@ -6548,21 +6522,6 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -6695,10 +6654,6 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-native-promise-only@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -7504,12 +7459,6 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -9467,10 +9416,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-samsam@1.x, samsam@^1.1.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-
 sane@^2.0.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
@@ -9746,19 +9691,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 simple-html-tokenizer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
-
-sinon@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.4.1.tgz#021fd64b54cb77d9d2fb0d43cdedfae7629c3a36"
-  dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
-    lolex "^1.6.0"
-    native-promise-only "^0.8.1"
-    path-to-regexp "^1.7.0"
-    samsam "^1.1.3"
-    text-encoding "0.6.4"
-    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -10469,7 +10401,7 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar@^2.0.0, tar@^2.2.1, tar@^2.2.2:
+tar@^2.0.0, tar@^2.2.1, tar@^2.2.2, tar@^4:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
   integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
@@ -10477,19 +10409,6 @@ tar@^2.0.0, tar@^2.2.1, tar@^2.2.2:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 test-exclude@^4.1.1:
   version "4.2.0"
@@ -10500,10 +10419,6 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
-
-text-encoding@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -10706,7 +10621,7 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
@@ -11589,11 +11504,6 @@ y18n@^3.2.0, y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
@magcurt8 @abehrman89 CR please

cc: @maxnovak @jdanz 

- Removes `sinon` because it was not being used very much (and we have `jest` mock functions instead) and it resolved to a vulnerable version of [diff](https://github.com/policygenius/athenaeum/network/alert/yarn.lock/diff/open)

Another PR is being put up to upgrade `jest` which will completely fix the `diff` vulnerability