### PR TITLE
Use sonar-scanner image and allow soft fails for SonarQube build steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,16 +31,18 @@ steps:
 
   - wait
 
-  - name: ':sonar-scanner:'
-    branches: master
+  - name: ':sonarqube:'
+    branches: 'master'
     command: bin/sonar
     agents:
       queue: runner
     plugins:
       docker-compose:
         run: athenaeum
+    soft_fail:
+      - exit_status: 1
 
-  - name: ':speaker: :sparkle: Automated Code Review'
+  - name: ':sonarqube: Automated Code Review'
     branches: "!master !hotfix/*"
     command: bin/scan-pullrequest
     agents:
@@ -48,6 +50,8 @@ steps:
     plugins:
       docker-compose:
         run: athenaeum
+    soft_fail:
+      - exit_status: 1
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       queue: runner
     plugins:
       docker-compose:
-        run: athenaeum
+        run: athenaeum-sonar
     soft_fail:
       - exit_status: 1
 
@@ -49,7 +49,7 @@ steps:
       queue: runner
     plugins:
       docker-compose:
-        run: athenaeum
+        run: athenaeum-sonar
     soft_fail:
       - exit_status: 1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,12 @@ services:
       - ./styleguide:/app/styleguide
       - .:/go/src/github.com/buildkite/agent
       - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
-      - ./coverage:/app/coverage
     command: yarn run build
     environment:
       - BUILDKITE
       - BUILDKITE_COMMIT
       - BUILDKITE_BRANCH
       - BUILDKITE_PULL_REQUEST
-      - BUILDKITE_PULL_REQUEST_BASE_BRANCH
       - BUILDKITE_REPO
       - BUILDKITE_BUILD_ID=$BUILDKITE_BUILD_ID
       - BUILDKITE_AGENT_ACCESS_TOKEN=$BUILDKITE_AGENT_ACCESS_TOKEN
@@ -25,5 +23,20 @@ services:
       - NPM_PASSWORD
       - NPM_TOKEN
       - NPM_EMAIL
+  athenaeum-sonar:
+    image: us.gcr.io/pg-shared-v1/sonar-scanner:28
+    working_dir: /app
+    volumes:
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+      - /app/coverage:/app/coverage
+      - ./:/app
+      - .:/go/src/github.com/buildkite/agent
+    environment:
+      - BUILDKITE_BUILD_ID=$BUILDKITE_BUILD_ID
+      - BUILDKITE_AGENT_ACCESS_TOKEN=$BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_BRANCH
+      - BUILDKITE_PULL_REQUEST
+      - BUILDKITE_PULL_REQUEST_BASE_BRANCH
+      - BUILDKITE_REPO
       - GITHUB_TOKEN
       - SONAR_LOGIN


### PR DESCRIPTION
This commit allows SonarQube build steps to soft fail, meaning that the build will not be blocked when these steps fail.

Additionally, the `sonar-scanner` step will also be using a specific image to run the `sonar-scanner` tool.