### PR TITLE
Fix bin/sonar to use /bin/sh instead of /bin/bash

### DIFF
--- a/bin/sonar
+++ b/bin/sonar
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 buildkite-agent artifact download coverage/lcov.info coverage/ --build ${BUILDKITE_BUILD_ID}
 


### PR DESCRIPTION
Small change to make `bin/sonar` script work. The sonar image needs to use `sh` instead of `bash`. This should fix the broken build.
 :man_facepalming: 