### PR TITLE
WINNE-575: Fixing button styles

### DIFF
--- a/src/atoms/Button/Readme.md
+++ b/src/atoms/Button/Readme.md
@@ -1,36 +1,102 @@
-Default Button Example:
+## Button Variants
+Buttons come in a few variants, which change their look-and-feel.
+The Buttons in these examples also have icons to demonstrate how the icon adapts to the variant.
 
+### Default
 ```jsx
-  <Button onClick={() => alert('Button clicked')} icon='lock'>Default Button</Button>
+<Button
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Default Button
+</Button>
 ```
 
-Info Button Example:
-
+#### Default Outlined
 ```jsx
-      <Button variant='info'>Info</Button>
+<Button
+  outline
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Outlined Default Button
+</Button>
 ```
 
-Outline Button Example:
-
+#### Default Disabled
 ```jsx
-      <Button outline>Outline Button</Button>
+<Button
+  disabled
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Disabled Default Button
+</Button>
 ```
 
-Outline Info Button Example:
-
+#### Default Outlined + Disabled
 ```jsx
-      <Button variant='info' outline>Info</Button>
+<Button
+  outline
+  disabled
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Disabled Outlined Default Button
+</Button>
 ```
 
-Disabled Unflexed Button Example:
-
+### Info
 ```jsx
-      <Button disabled unflex>Disabled</Button>
+<Button
+  variant='info'
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Info Button
+</Button>
 ```
 
-Disabled Unflexed Outline Button Example:
-
+#### Info Outlined
 ```jsx
-      <Button disabled unflex outline>Disabled</Button>
+<Button
+  outline
+  variant='info'
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Info Outlined Button
+</Button>
 ```
 
+#### Info Disabled
+```jsx
+<Button
+  disabled
+  variant='info'
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Disabled Info Button
+</Button>
+```
+
+#### Info Outlined + Disabled
+```jsx
+<Button
+  outline
+  disabled
+  variant='info'
+  icon='lock'
+  onClick={() => alert('Button clicked')}
+>
+  Disabled Outlined Info Button
+</Button>
+```
+
+## Unflexed Buttons
+Buttons can also be unflexed, so that they will not expand to fill their parent
+
+```jsx
+<Button unflex>Unflexed Button</Button>
+```

--- a/src/atoms/Button/buttons.module.scss
+++ b/src/atoms/Button/buttons.module.scss
@@ -30,36 +30,25 @@ $brand-white: color('primary-2');
   width: 100%;
   outline: none;
   white-space: normal;
-  border-radius: 0;
 
   &:active,
   &:focus {
     outline: none;
   }
 
-  .icon {
-    path {
-      transition: fill 300ms ease-out;
-      fill: $brand-white;
-    }
+  .icon path {
+    transition: fill 300ms ease-out;
+    fill: $brand-white;
   }
 
   &.outline {
     background-color: transparent;
     color: $action-color;
     border: 2px solid inherit;
-  }
-}
 
-.disabled {
-  background-color: color('neutral-4');
-  border: 2px solid color('neutral-4');
-  cursor: not-allowed;
-  user-select: none;
-
-  &.outline {
-    background-color: transparent;
-    color: color('neutral-4');
+    .icon path {
+      fill: $action-color;
+    }
   }
 }
 
@@ -93,6 +82,10 @@ $brand-white: color('primary-2');
     background-color: transparent;
     color: $info-color;
     border: 2px solid inherit;
+
+    .icon path {
+      fill: $info-color;
+    }
   }
 }
 
@@ -102,6 +95,22 @@ $brand-white: color('primary-2');
   padding-left: rem-calc(19);
   padding-right: rem-calc(19);
   display: inline-block;
+}
+
+.disabled {
+  background-color: color('neutral-4');
+  border: 2px solid color('neutral-4');
+  cursor: not-allowed;
+  user-select: none;
+
+  &.outline {
+    background-color: transparent;
+    color: color('neutral-4');
+
+    .icon path {
+      fill: color('neutral-4');
+    }
+  }
 }
 
 @media #{$tablet} {

--- a/src/atoms/Button/index.js
+++ b/src/atoms/Button/index.js
@@ -40,7 +40,7 @@ function Button( props ) {
         href={href}
         {...linkAttrs}
       >
-        { icon && <Icon icon={icon} className={styles['icon']} /> }
+        { icon && <Icon icon={icon} renderSVGDOM className={styles['icon']} /> }
         { children || text }
       </a>
     );
@@ -48,7 +48,7 @@ function Button( props ) {
 
   return (
     <button className={classnames(...classes)} type={type} disabled={disabled} {...rest}>
-      { icon && <Icon icon={icon} className={styles['icon']} /> }
+      { icon && <Icon icon={icon} renderSVGDOM className={styles['icon']} /> }
       { children || text }
     </button>
   );


### PR DESCRIPTION
- When a button of any `variant` is disabled, it should appear grayed
out. Previously, this styling had not been applied outlined,
variant=info buttons.
- Also, a button's icon (if present) should be colored to match the text
of the button.
- This also adjusts the styleguidist docs page for buttons, showcasing
the outlined and disabled forms of each variant.