### PR TITLE
Replace deprecated Text type with size

### DIFF
--- a/src/atoms/LinkWrapper/Readme.md
+++ b/src/atoms/LinkWrapper/Readme.md
@@ -10,7 +10,7 @@ Primary Link:
 
 ```jsx
   <LinkWrapper type='primary' href='#'>
-    <Text type={8} font='b' bold inherit>This is a link!</Text>
+    <Text size={8} font='b' bold inherit>This is a link!</Text>
   </LinkWrapper>
 ```
 
@@ -18,7 +18,7 @@ Secondary Link:
 
 ```jsx
   <LinkWrapper type='secondary' href='#'>
-    <Text type={10} font='b'>This is a link!</Text>
+    <Text size={10} font='b'>This is a link!</Text>
   </LinkWrapper>
 ```
 

--- a/src/atoms/Text/Readme.md
+++ b/src/atoms/Text/Readme.md
@@ -6,17 +6,17 @@ Text A Example:
 ```jsx
 
     <div>
-      <Text type={1} font='a'>Type A1</Text>
-      <Text type={2} font='a'>Type A2</Text>
-      <Text type={3} font='a'>Type A3</Text>
-      <Text type={4} font='a'>Type A4</Text>
-      <Text type={5} font='a'>Type A5</Text>
-      <Text type={6} font='a'>Type A6</Text>
-      <Text type={7} font='a'>Type A7</Text>
-      <Text type={8} font='a'>Type A8</Text>
-      <Text type={9} font='a'>Type A9</Text>
-      <Text type={10} font='a'>Type A10</Text>
-      <Text type={11} font='a'>Type A11</Text>
+      <Text size={1} font='a'>Type A1</Text>
+      <Text size={2} font='a'>Type A2</Text>
+      <Text size={3} font='a'>Type A3</Text>
+      <Text size={4} font='a'>Type A4</Text>
+      <Text size={5} font='a'>Type A5</Text>
+      <Text size={6} font='a'>Type A6</Text>
+      <Text size={7} font='a'>Type A7</Text>
+      <Text size={8} font='a'>Type A8</Text>
+      <Text size={9} font='a'>Type A9</Text>
+      <Text size={10} font='a'>Type A10</Text>
+      <Text size={11} font='a'>Type A11</Text>
     </div>
 ```
 
@@ -25,8 +25,8 @@ Text A Spaced Example:
 ```jsx
 
     <div>
-      <Text type={9} font='a' spaced>Type A9</Text>
-      <Text type={11} font='a' spaced>Type A11</Text>
+      <Text size={9} font='a' spaced>Type A9</Text>
+      <Text size={11} font='a' spaced>Type A11</Text>
     </div>
 ```
 
@@ -35,12 +35,12 @@ Text B Example:
 ```jsx
 
     <div>
-      <Text type={5} font='b'>Type B5</Text>
-      <Text type={6} font='b'>Type B6</Text>
-      <Text type={7} font='b'>Type B7</Text>
-      <Text type={8} font='b'>Type B8</Text>
-      <Text type={10} font='b'>Type B10</Text>
-      <Text type={12} font='b'>Type B11</Text>
+      <Text size={5} font='b'>Type B5</Text>
+      <Text size={6} font='b'>Type B6</Text>
+      <Text size={7} font='b'>Type B7</Text>
+      <Text size={8} font='b'>Type B8</Text>
+      <Text size={10} font='b'>Type B10</Text>
+      <Text size={12} font='b'>Type B11</Text>
     </div>
 ```
 
@@ -49,6 +49,6 @@ Text C Example:
 ```jsx
 
     <div>
-      <Text type={7} font='c'>Type C7</Text>
+      <Text size={7} font='c'>Type C7</Text>
     </div>
 ```

--- a/src/atoms/UserAlert/Readme.md
+++ b/src/atoms/UserAlert/Readme.md
@@ -6,7 +6,7 @@
       onClick={() => alert('you clicked me')}
     >
       <Text
-        type={6}
+        size={6}
         color='neutral-8'
         semibold
       >

--- a/src/molecules/FeatureSquare/index.js
+++ b/src/molecules/FeatureSquare/index.js
@@ -30,8 +30,8 @@ function FeatureSquare(props) {
   return (
     <div className={classnames(...classes)}>
       <Icon icon={icon} className={styles['icon']} width='100px' />
-      <Text type={5} font='a'>{ header }</Text>
-      <Text type={8} className={styles['subheader']}>{ subheader }</Text>
+      <Text size={5} font='a'>{ header }</Text>
+      <Text size={8} className={styles['subheader']}>{ subheader }</Text>
       <Layout smallCols={[ 6 ]} className={styles['button-wrapper']}>
         <Button onClick={onClick} outline className={styles['button']}>{ buttonText }</Button>
       </Layout>

--- a/src/molecules/MobileMenu/index.js
+++ b/src/molecules/MobileMenu/index.js
@@ -41,7 +41,7 @@ function MobileMenu(props) {
           <Text
             className={styles['tag-text']}
             tag='span'
-            type={7}
+            size={7}
             color='primary-3'
             font='a'
           >

--- a/src/molecules/Modal/index.js
+++ b/src/molecules/Modal/index.js
@@ -147,7 +147,7 @@ class Modal extends React.Component {
                   </div>
 
                   <Text
-                    type={3}
+                    size={3}
                     font='a'
                   >
                     {header}

--- a/src/molecules/StepIndicator/ProgressBarStep.js
+++ b/src/molecules/StepIndicator/ProgressBarStep.js
@@ -85,7 +85,7 @@ export default class ProgressBarStep extends Component {
     return (
       <div className={styles['breadcrumb']} {...this.clickProps()}>
         <div className={classnames(this.textClasses())}>
-          <Text tag='span' type={11} font='a' spaced className={styles['step-title']} {...this.titleProps()}>{ step.text }</Text>
+          <Text tag='span' size={11} font='a' spaced className={styles['step-title']} {...this.titleProps()}>{ step.text }</Text>
         </div>
         <div className={classnames(...this.circleWrapperClasses())}>
           <div className={classnames(...this.circleClasses())} />
@@ -93,7 +93,7 @@ export default class ProgressBarStep extends Component {
         {
           step.subtitle && (
             <div className={styles['step-subtitle']}>
-              <Text tag='span' type={9} font='b' {...this.subtitleProps()}>{step.subtitle}</Text>
+              <Text tag='span' size={9} font='b' {...this.subtitleProps()}>{step.subtitle}</Text>
             </div>
           )
         }

--- a/src/molecules/lists/IconList/index.js
+++ b/src/molecules/lists/IconList/index.js
@@ -29,7 +29,7 @@ function IconList(props) {
           >
             <Text
               className={styles.text}
-              type={type}
+              size={type}
               font={font}
             >
               <Icon

--- a/src/organisms/cards/FeaturedPolicyCard/PolicyInformation.js
+++ b/src/organisms/cards/FeaturedPolicyCard/PolicyInformation.js
@@ -24,7 +24,7 @@ const renderPolicyInformation = (info, idx) => (
           className={styles['policy-info-tooltip-icon']}
           text={(
             <Text
-              type={10}
+              size={10}
               font='b'
               tag='span'
               className={styles['policy-info-tooltip-label']}
@@ -36,7 +36,7 @@ const renderPolicyInformation = (info, idx) => (
           {info.hoverMessage}
         </Tooltip>
       </Col>
-      <Text type={8} font='a' semibold>{formatValue(info.value)}</Text>
+      <Text size={8} font='a' semibold>{formatValue(info.value)}</Text>
     </Layout>
     <Spacer spacer={2} />
   </div>

--- a/src/organisms/cards/FeaturedPolicyCard/Readme.md
+++ b/src/organisms/cards/FeaturedPolicyCard/Readme.md
@@ -31,7 +31,7 @@
         defaultText: 'Quote available from a PolicyGenius expert'
       }}
       discount={(
-        <Text color='neutral-1' type={7}>
+        <Text color='neutral-1' size={7}>
           Save 5% when paying annually
         </Text>
       )}

--- a/src/organisms/cards/FeaturedPolicyCard/index.js
+++ b/src/organisms/cards/FeaturedPolicyCard/index.js
@@ -71,7 +71,7 @@ function FeaturedPolicyCard(props) {
               </Text>
               <Text
                 tag='span'
-                type={11}
+                size={11}
                 font='a'
                 spaced
                 color='neutral-2'
@@ -87,7 +87,7 @@ function FeaturedPolicyCard(props) {
           </div>
         )
           :
-          <Text type={7} color='neutral-2' className={styles['default-text']}>{premium.defaultText}</Text>}
+          <Text size={7} color='neutral-2' className={styles['default-text']}>{premium.defaultText}</Text>}
 
         <Spacer spacer={6} />
 

--- a/src/organisms/cards/PlaybackCard/index.js
+++ b/src/organisms/cards/PlaybackCard/index.js
@@ -34,7 +34,7 @@ function PlaybackCard(props) {
           >
             <Text
               tag='span'
-              type={10}
+              size={10}
               font='b'
             >
               { editLinkText }

--- a/src/organisms/cards/PolicyCard/PolicyActions.js
+++ b/src/organisms/cards/PolicyCard/PolicyActions.js
@@ -32,8 +32,8 @@ export const PolicyActions = (props) => {
     <div className={styles['actions']}>
       { premium.price ? (
         <div>
-          <Text type={11} font='a' color='neutral-2' bold>
-            <Text type={4} font='a' color='primary-3' bold>{formattedPremium}</Text>
+          <Text size={11} font='a' color='neutral-2' bold>
+            <Text size={4} font='a' color='primary-3' bold>{formattedPremium}</Text>
             {'/'}
             {premium.format.toUpperCase()}
           </Text>

--- a/src/organisms/cards/PolicyCard/PolicyInformation.js
+++ b/src/organisms/cards/PolicyCard/PolicyInformation.js
@@ -14,10 +14,10 @@ export const PolicyInformation = ({ information }) => (
       information.map((item, idx) => (
         <Tooltip
           text={(
-            <Text type={11} bold spaced color='neutral-2' font='a'>
+            <Text size={11} bold spaced color='neutral-2' font='a'>
               <Layout smallCols={[ 7, 5 ]} fullwidth>
                 <div className={styles['policy-info-label']}>{item.label.toUpperCase()}</div>
-                <Text type={8} font='a' semibold>{formatValue(item.value)}</Text>
+                <Text size={8} font='a' semibold>{formatValue(item.value)}</Text>
               </Layout>
             </Text>
           )}

--- a/src/organisms/cards/PolicyCard/PolicyType.js
+++ b/src/organisms/cards/PolicyCard/PolicyType.js
@@ -26,7 +26,7 @@ export const PolicyType = ({
             </Text>
           </Hide>
           <Text
-            type={7}
+            size={7}
             font='a'
             semibold
             className={styles['policy-name']}
@@ -34,7 +34,7 @@ export const PolicyType = ({
             {value}
           </Text>
           <Text
-            type={7}
+            size={7}
             color='neutral-2'
             semibold
             className={styles['policy-tooltip']}

--- a/src/organisms/cards/PolicyCard/Readme.md
+++ b/src/organisms/cards/PolicyCard/Readme.md
@@ -48,8 +48,8 @@
         defaultText: 'Quote available from a PolicyGenius expert'
       }}
       discount={(
-        <Text color='neutral-3' type={7} light>
-          <Text semibold type={7}>Save 5%</Text>
+        <Text color='neutral-3' size={7} light>
+          <Text semibold size={7}>Save 5%</Text>
           { ' ' }
           when paying annually
         </Text>

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/index.js
@@ -36,17 +36,17 @@ function SimpleFeaturedPolicyCard(props) {
         { premium.price ? (
           <div className={styles['premium']}>
             <Text
-              type={3}
+              size={3}
               font='a'
             >
-              {formattedPremium} <Text tag='span' type={11} font='a' spaced color='neutral-2'>{`/${premium.format.toUpperCase()}`}</Text>
+              {formattedPremium} <Text tag='span' size={11} font='a' spaced color='neutral-2'>{`/${premium.format.toUpperCase()}`}</Text>
             </Text>
 
             {premium.tooltip}
           </div>
         )
           :
-          <Text type={7} font='a'>{premium.defaultText}</Text>}
+          <Text size={7} font='a'>{premium.defaultText}</Text>}
 
         <Spacer size={24} />
 

--- a/src/organisms/cards/SimplePolicyCard/Premium.js
+++ b/src/organisms/cards/SimplePolicyCard/Premium.js
@@ -13,17 +13,17 @@ export const Premium = ({ premium }) => {
       {
         premium.price ? (
           <Text
-            type={4}
+            size={4}
             font='a'
             className={styles['premium-text']}
           >
             {formattedPremium}
             {' '}
-            <Text tag='span' type={11} font='a' spaced color='neutral-2'>{`/${premium.format.toUpperCase()}`}</Text>
+            <Text tag='span' size={11} font='a' spaced color='neutral-2'>{`/${premium.format.toUpperCase()}`}</Text>
           </Text>
         )
           :
-          <Text type={7} font='a'>{premium.defaultText}</Text>
+          <Text size={7} font='a'>{premium.defaultText}</Text>
       }
 
       {premium.tooltip}

--- a/src/organisms/cards/SimplePolicyCard/Readme.md
+++ b/src/organisms/cards/SimplePolicyCard/Readme.md
@@ -53,7 +53,7 @@ No Compare Example:
 ```jsx
     <SimplePolicyCard
       carrierLogo={
-        <Text font='a' type={7}>Multiple companies available</Text>
+        <Text font='a' size={7}>Multiple companies available</Text>
       }
       premium={{
         price: 13,
@@ -62,9 +62,9 @@ No Compare Example:
         tooltip:
           <Tooltip text={<LinkWrapper type='secondary'>approx.</LinkWrapper>}>
             <div>
-              <Text font='a' type={10}>This is a header</Text>
+              <Text font='a' size={10}>This is a header</Text>
               <Spacer size={12} />
-              <Text type={10}>And here's more additional text</Text>
+              <Text size={10}>And here's more additional text</Text>
             </div>
           </Tooltip>
       }}
@@ -78,7 +78,7 @@ No CTA Example:
 ```jsx
     <SimplePolicyCard
       carrierLogo={
-        <Text font='a' type={7}>Multiple companies available</Text>
+        <Text font='a' size={7}>Multiple companies available</Text>
       }
       premium={{
         price: 13,
@@ -87,9 +87,9 @@ No CTA Example:
         tooltip:
           <Tooltip text={<LinkWrapper type='secondary'>approx.</LinkWrapper>}>
             <div>
-              <Text font='a' type={10}>This is a header</Text>
+              <Text font='a' size={10}>This is a header</Text>
               <Spacer size={12} />
-              <Text type={10}>And here's more additional text</Text>
+              <Text size={10}>And here's more additional text</Text>
             </div>
           </Tooltip>
       }}

--- a/src/organisms/tables/ComparisonTable/Readme.md
+++ b/src/organisms/tables/ComparisonTable/Readme.md
@@ -21,7 +21,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       subHeader='These prices are very close! Rates are very competitive right now, especially for people with your profile.'
     >
     <Text
-      type={7}
+      size={7}
       font='a'
     >
       Cost
@@ -44,13 +44,13 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       subHeader='The amount of money your benficiaries would receive.'
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Coverage Amount
       </Text>
       <Text
-        type={5}
+        size={5}
         font='a'
       >
         $500,000
@@ -58,13 +58,13 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
     </ComparisonTable.Row>
     <ComparisonTable.Row>
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Term
       </Text>
       <Text
-        type={5}
+        size={5}
         font='a'
       >
         20 Years
@@ -88,7 +88,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
 
   <ComparisonTable.Table>
     <ComparisonTable.Header>
-      <Text font='a' type={5}>Important Stuff</Text>
+      <Text font='a' size={5}>Important Stuff</Text>
       <div>
         <Icon
           icon='policygeniusSymbol'
@@ -102,7 +102,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
     </ComparisonTable.Header>
     <ComparisonTable.Row>
     <Text
-      type={7}
+      size={7}
       font='a'
     >
       Very imporant stuff
@@ -113,7 +113,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       subHeader='Important to know but not super important'
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Some stuff you should know
@@ -151,7 +151,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       outlineMissing
     >
     <Text
-      type={7}
+      size={7}
       font='a'
     >
       Cost
@@ -175,13 +175,13 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       showMissing
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Coverage Amount
       </Text>
       <Text
-        type={5}
+        size={5}
         font='a'
       >
         $500,000
@@ -191,13 +191,13 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       showMissing
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Term
       </Text>
       <Text
-        type={5}
+        size={5}
         font='a'
       >
         20 Years
@@ -221,7 +221,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
 
   <ComparisonTable.Table tableItems={1}>
     <ComparisonTable.Header>
-      <Text font='a' type={5}>Important Stuff</Text>
+      <Text font='a' size={5}>Important Stuff</Text>
       <div>
         <Icon
           icon='policygeniusSymbol'
@@ -230,7 +230,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
     </ComparisonTable.Header>
     <ComparisonTable.Row>
     <Text
-      type={7}
+      size={7}
       font='a'
     >
       Very imporant stuff
@@ -241,7 +241,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       subHeader='Important to know but not super important'
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Some stuff you should know
@@ -252,7 +252,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
 
   <ComparisonTable.Table tableItems={1}>
     <ComparisonTable.Header showMissing outlineMissing>
-      <Text font='a' type={5}>Important Stuff</Text>
+      <Text font='a' size={5}>Important Stuff</Text>
       <div>
         <Icon
           icon='policygeniusSymbol'
@@ -261,7 +261,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
     </ComparisonTable.Header>
     <ComparisonTable.Row showMissing outlineMissing>
     <Text
-      type={7}
+      size={7}
       font='a'
     >
       Very imporant stuff
@@ -274,7 +274,7 @@ const { Premium } = require('organisms/cards/SimplePolicyCard/Premium');
       outlineMissing
     >
       <Text
-        type={7}
+        size={7}
         font='a'
       >
         Some stuff you should know

--- a/src/organisms/tables/ComparisonTable/index.js
+++ b/src/organisms/tables/ComparisonTable/index.js
@@ -246,7 +246,7 @@ class TableRow extends React.Component {
           <Text
             className={styles['sub-header-text']}
             font='b'
-            type={10}
+            size={10}
           >
             {subHeader}
           </Text>

--- a/src/templates/CheckOut/index.js
+++ b/src/templates/CheckOut/index.js
@@ -112,7 +112,7 @@ function CheckOut(props) {
                     <Col fullwidth className={styles['cost-price']}>
                       { curr && <sup>{curr}</sup> }
                       { value }
-                      { unit && <Text type={10} font='b' tag='span'>{unit}</Text> }
+                      { unit && <Text size={10} font='b' tag='span'>{unit}</Text> }
                     </Col>
                   </Layout>
                 </Col>

--- a/src/templates/Navigator/index.js
+++ b/src/templates/Navigator/index.js
@@ -85,7 +85,7 @@ function Navigator(props) {
                     <Icon icon='pgLogoBlack' className={styles['logo']} />
 
                     <Hide hideOn='mobile tablet'>
-                      <Text className={styles['logo-panel-text']} type={6} font='b'>
+                      <Text className={styles['logo-panel-text']} size={6} font='b'>
                         { leftRailText }
                       </Text>
                     </Hide>
@@ -106,7 +106,7 @@ function Navigator(props) {
                   />
 
                   <Hide hideOn='mobile desktop'>
-                    <Text className={styles['logo-panel-text']} type={6} font='b'>
+                    <Text className={styles['logo-panel-text']} size={6} font='b'>
                       { leftRailText }
                     </Text>
                   </Hide>


### PR DESCRIPTION
**Purpose**
Unticketed cleanup work in athenaeum to remove a deprecated tag from documentation/components. (`type` is deprecated)

**Changes**
Replace all occurrences of `<Text type...` with `<Text size...`