### PR TITLE
Fix: Update RadioField checked status and FullDateField proptypes

### DIFF
--- a/src/molecules/formfields/FullDateField/index.js
+++ b/src/molecules/formfields/FullDateField/index.js
@@ -73,9 +73,13 @@ FullDateField.propTypes = {
   fieldRef: PropTypes.func,
 
   /**
-   * Adds a tooltip to the label. Provide string for text to be placed inside tooltip popup
+   * Either a handler for clicking the tooltip, or text to go in the tooltip for the label
    */
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.object
+  ]),
 
   /**
    * Passes dayInputProps, monthInputProps, yearInputProps and fieldClass to provided function

--- a/src/molecules/formfields/RadioField/index.js
+++ b/src/molecules/formfields/RadioField/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import camelCase from 'lodash/camelCase';
 import omit from 'lodash/omit';
+import isUndefined from 'lodash/isUndefined';
 import classnames from 'classnames';
 
 import styles from './radio_field.module.scss';
@@ -19,10 +20,13 @@ function RadioField(props) {
     className,
   ];
 
+  const isChecked = !isUndefined(input.checked) ? input.checked
+    : input.value && input.value === radioValue;
+
   const labelClasses = [
     styles['label'],
-    input.value === radioValue && styles['checked'],
-    input.value && input.value !== radioValue && styles['not-selected'],
+    isChecked && styles['checked'],
+    !isChecked && styles['not-selected'],
   ];
 
   return (
@@ -67,7 +71,16 @@ RadioField.propTypes = {
   /**
    * The props under the input key are passed from `redux-form` and spread into `<input />`.
    */
-  input: PropTypes.object.isRequired,
+  input: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    checked: PropTypes.bool,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool,
+      PropTypes.number
+    ]).isRequired,
+    onChange: PropTypes.func.isRequired
+  }).isRequired,
 
   /**
    * Value for radio field


### PR DESCRIPTION
1. Update `RadioField` component to use `input.checked` value if available. Otherwise, use the the current way of determining the checked status.
     - This is related to updating `react-final-form` to the latest version in `winnebago`: https://github.com/policygenius/winnebago/pull/578
2. Update the `FullDateField` component's `PropTypes` for `tooltip`. It was expecting on a `string`, but we oftentimes send functions that render a `ToolTip` component. 
     - This clears a warning in the console in `winnebago` at the very least