### PR TITLE
Add policyScan icon to PropTypes

### DIFF
--- a/src/atoms/Icon/constants.js
+++ b/src/atoms/Icon/constants.js
@@ -201,6 +201,7 @@ module.exports = {
     'plus',
     'policygeniusSymbol',
     'policygeniusSymbolCenter',
+    'policyScan',
     'priceRibbon',
     'priceSticker',
     'priceTag',


### PR DESCRIPTION
- Adds the `policyScan` icon to the list of `PropTypes` for the `Icon` component

**Context**
Without this prop type specified, we get an ugly error in our console in dev mode. This should have been done months ago, but alas, here we are.

Example error:
![Screen Shot 2020-05-20 at 1 30 45 PM](https://user-images.githubusercontent.com/17008820/82478020-41f05080-9a9e-11ea-8fe4-c4124632880a.png)
