### PR TITLE
Add default props to AccountIndicator for links

### DIFF
--- a/src/molecules/AccountIndicator/index.js
+++ b/src/molecules/AccountIndicator/index.js
@@ -209,4 +209,9 @@ AccountIndicator.propTypes = {
   onMenuLinkClick: PropTypes.func
 };
 
+AccountIndicator.defaultProps = {
+  dashboardPath: '/users/dashboard',
+  logoutPath: '/users/sign_out'
+};
+
 export default AccountIndicator;


### PR DESCRIPTION
This commit adds default paths to logout and dashboard links in the
AccountIndicator component.