### PR TITLE
add optional hideChat prop

### DIFF
--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -100,6 +100,7 @@ function renderPhoneInfo(phoneNumber, hours) {
 function Footer(props) {
   const {
     className,
+    hideChat,
     phoneNumber,
     emailAddress,
     links,
@@ -180,13 +181,13 @@ function Footer(props) {
 
           <Spacer size={18} />
 
-          <Button
+          { !hideChat && <Button
             variant='info'
             outline
             onClick={onClickChat}
           >
           Live Chat
-          </Button>
+          </Button> }
 
           <Spacer size={18} />
 
@@ -235,7 +236,10 @@ Footer.propTypes = {
    * provided in the component's index.js file.
    */
   className: PropTypes.string,
-
+  /**
+   * This prop will conditionally render the live chat button on mobile
+   */
+  hideChat: PropTypes.bool,
   /**
    * Formatted Contact phone number. Can be wrapped in additional markup
    */
@@ -273,7 +277,8 @@ Footer.propTypes = {
 };
 
 Footer.defaultProps = {
-  emailAddress: 'team@policygenius.com'
+  emailAddress: 'team@policygenius.com',
+  hideChat: false
 };
 
 export default Footer;

--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -181,13 +181,15 @@ function Footer(props) {
 
           <Spacer size={18} />
 
-          { !hideChat && <Button
-            variant='info'
-            outline
-            onClick={onClickChat}
-          >
-          Live Chat
-          </Button> }
+          {!hideChat && (
+            <Button
+              variant='info'
+              outline
+              onClick={onClickChat}
+            >
+            Live Chat
+            </Button>
+          )}
 
           <Spacer size={18} />
 
@@ -236,10 +238,13 @@ Footer.propTypes = {
    * provided in the component's index.js file.
    */
   className: PropTypes.string,
+
   /**
    * This prop will conditionally render the live chat button on mobile
    */
+
   hideChat: PropTypes.bool,
+
   /**
    * Formatted Contact phone number. Can be wrapped in additional markup
    */

--- a/src/templates/Footer/index.js
+++ b/src/templates/Footer/index.js
@@ -242,7 +242,6 @@ Footer.propTypes = {
   /**
    * This prop will conditionally render the live chat button on mobile
    */
-
   hideChat: PropTypes.bool,
 
   /**


### PR DESCRIPTION
[LIFE-826](https://policygenius.atlassian.net/browse/LIFE-826)

## Purpose
We want to hide the chat button on mobile, to give a better experience for users coming from the `Merlin` app, but also because mobile users don't really chat anyways

## Changes
- Added optional `hideChat` prop to the `Footer` component to conditionally show chat button on mobile
- Defaulted `hideChat` to false to not mess with other flows