### PR TITLE
allow tooltip to be a func

### DIFF
--- a/src/molecules/formfields/DateField/index.js
+++ b/src/molecules/formfields/DateField/index.js
@@ -52,9 +52,13 @@ DateField.propTypes = {
   fieldRef: PropTypes.func,
 
   /**
-   * Adds a tooltip to the label. Provide string for text to be placed inside tooltip popup
+   * either a handler for clicking the tooltip, or text to go in the tooltip for the label
    */
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.object
+  ]),
 };
 
 export default DateField;

--- a/src/molecules/formfields/ShortDateField/index.js
+++ b/src/molecules/formfields/ShortDateField/index.js
@@ -73,9 +73,13 @@ ShortDateField.propTypes = {
   fieldRef: PropTypes.func,
 
   /**
-   * Adds a tooltip to the label. Provide string for text to be placed inside tooltip popup
+   * either a handler for clicking the tooltip, or text to go in the tooltip for the label
    */
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.object
+  ]),
 
   /**
    * Passes dayInputProps, monthInputProps, yearInputProps and fieldClass to provided function

--- a/src/molecules/formfields/util/BaseDateField/index.js
+++ b/src/molecules/formfields/util/BaseDateField/index.js
@@ -397,9 +397,13 @@ BaseDateField.propTypes = {
   fieldRef: PropTypes.func,
 
   /**
-   * Adds a tooltip to the label. Provide string for text to be placed inside tooltip popup
+   * either a handler for clicking the tooltip, or text to go in the tooltip for the label
    */
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.object
+  ]),
 };
 
 export default BaseDateField;


### PR DESCRIPTION
[LIFE-1065](https://policygenius.atlassian.net/browse/LIFE-1065)

Tooltips are not currently tracked in lifeweb analytics. This PR allows us to pass tooltips from life-web with all the necessary analytics events to athenaeum for rendering in form fields.