### PR TITLE
Remove justify-content: end from AccountIndicator

### DIFF
--- a/src/molecules/AccountIndicator/Readme.md
+++ b/src/molecules/AccountIndicator/Readme.md
@@ -5,7 +5,7 @@ AccountIndicator Example:
     customerName='Franklin Roosevelt'
     customerEmail='franklin_roosevelt@gmail.com'
     dashboardPath='/dashboard'
-    isAccountHolder={true}
     logoutPath='/users/sign_out'
+    isAccountHolder
   />
 ```

--- a/src/molecules/AccountIndicator/Readme.md
+++ b/src/molecules/AccountIndicator/Readme.md
@@ -5,6 +5,7 @@ AccountIndicator Example:
     customerName='Franklin Roosevelt'
     customerEmail='franklin_roosevelt@gmail.com'
     dashboardPath='/dashboard'
+    isAccountHolder={true}
     logoutPath='/users/sign_out'
   />
 ```

--- a/src/molecules/AccountIndicator/account_indicator.module.scss
+++ b/src/molecules/AccountIndicator/account_indicator.module.scss
@@ -8,7 +8,6 @@ $default-spacing: rem-calc(16px);
 .indicator {
   width: auto;
   display: flex;
-  justify-content: end;
   align-items: center;
   cursor: pointer;
 }


### PR DESCRIPTION
The usage of `justify-content: end` has 'mixed support' according to a couple of big ol' warnings in the chrome console. Since we're also using `display: flex`, I don't think `end` does anything (since it is for non-flex children).

https://developer.mozilla.org/en-us/docs/Web/CSS/justify-content#syntax