### PR TITLE
MOR-1, MOR-2, MOR-3, MOR-4, MOR-5: Brand color updates

### DIFF
--- a/src/assets/stylesheets/base_styles/_colors.scss
+++ b/src/assets/stylesheets/base_styles/_colors.scss
@@ -1,61 +1,82 @@
 $transparent-neutral-2: rgba(77, 77, 77, .8);
 
 $colors-map: (
-  /* Grey. From dark to light. */
-  neutral-1: #504a4a,
-  neutral-2: #808080,
-  neutral-3: #b2b2b2,
-  neutral-4: #d6d6d6,
-  /*
-    This color is a new addition that came too late in the rebrand
-    In order to preserve neutral-5 across our styles, we are temporarily
-    adding this color as an in between
-   */
-  neutral-4-5: #ededed,
-  neutral-5: #f5f5f5,
+  /* Non-semantic brand color tints & utility colors */
+  brand-white: #FFFFFF,
+  brand-black: #000000,
+  brand-gray-100: #F1F1F1,
+  brand-gray-200: #D9D9D9,
+  brand-gray-300: #C0C0C0,
+  brand-gray-400: #707070,
+  brand-gray-500: #383838,
 
-  /* Orange, white, black */
-  primary-1: #ff700a,
-  primary-2: #fff,
-  primary-3: #2b2727,
+  brand-orange-100: #FBEDE7,
+  brand-orange-200: #ECA389,
+  brand-orange-300: #FF6E00,
+  brand-orange-400: #D44513,
 
-  /* Assorted accent colors */
-  secondary-1: #7023ff,
-  secondary-2: #00aeff,
-  secondary-3: #ff3ab9,
-  secondary-4: #0c0,
-  secondary-5: #ffc700,
+  brand-blue-100: #E5EEF1,
+  brand-blue-200: #A8C4D0,
+  brand-blue-300: #005473,
+  brand-blue-400: #003245,
+
+  brand-green-100: #E5F1EF,
+  brand-green-200: #80BAB0,
+  brand-green-300: #007562,
+  brand-green-400: #013F3A,
+
+  brand-maroon-100: #E6D7DC,
+  brand-maroon-200: #C09BA7,
+  brand-maroon-300: #730024,
+  brand-maroon-400: #470304,
+
+  utility-red: #AC0036,
+
+  /* Semantic names for raw color tints */
+  neutral-1: color('brand-gray-500'),
+  neutral-2: color('brand-gray-400'),
+  neutral-3: color('brand-gray-300'),
+  neutral-4: color('brand-gray-200'),
+  neutral-5: color('brand-gray-100'),
+
+  primary-1: color('brand-orange-400'),
+  primary-2: color('brand-white'),
+  primary-3: color('brand-gray-500'),
+
+  secondary-1: color('brand-blue-300'),
+  secondary-2: color('brand-orange-300'),
+  secondary-3: color('brand-green-300'),
 );
 
 $backwards-compat-colors-map: (
   /* Black. From dark to light. */
-  neutral-6: #f5f5f5,
-  neutral-7: #f5f5f5,
-  neutral-8: #fff,
+  neutral-6: color('brand-gray-100'),
+  neutral-7: color('brand-gray-100'),
+  neutral-8: color('brand-white'),
 
   /* Black. From dark to light. */
-  brand-1: #2b2727,
-  brand-2: #2b2727,
-  brand-3: #808080,
-  brand-4: #b2b2b2,
-  brand-5: #d6d6d6,
-  brand-6: #f5f5f5,
+  brand-1: color('brand-gray-500'),
+  brand-2: color('brand-gray-500'),
+  brand-3: color('brand-gray-400'),
+  brand-4: color('brand-gray-300'),
+  brand-5: color('brand-gray-200'),
+  brand-6: color('brand-gray-100'),
 
   /* Orange */
   accent-1: transparent,
-  accent-2: #ff700a,
-  accent-3: #ff700a,
-  accent-4: #ff700a,
-  accent-5: #ff700a,
-  accent-6: #ff700a,
+  accent-2: color('brand-orange-400'),
+  accent-3: color('brand-orange-400'),
+  accent-4: color('brand-orange-400'),
+  accent-5: color('brand-orange-400'),
+  accent-6: color('brand-orange-400'),
 
   /* Orange */
   action-1: transparent,
-  action-2: #ff700a,
-  action-3: #ff700a,
-  action-4: #ff700a,
-  action-5: #ff700a,
-  action-6: #ff700a,
+  action-2: color('brand-orange-400'),
+  action-3: color('brand-orange-400'),
+  action-4: color('brand-orange-400'),
+  action-5: color('brand-orange-400'),
+  action-6: color('brand-orange-400'),
 
   /* Modal overlay background */
   transparent-neutral-2: $transparent-neutral-2

--- a/src/atoms/Button/buttons.module.scss
+++ b/src/atoms/Button/buttons.module.scss
@@ -1,6 +1,6 @@
 $info-color: color('primary-3');
 $action-color: color('primary-1');
-$selected-color: color('secondary-2');
+$selected-color: color('secondary-1');
 $unselected-color: color('neutral-4');
 $brand-white: color('primary-2');
 
@@ -63,9 +63,9 @@ $brand-white: color('primary-2');
 }
 
 .toggle-selected {
-  color: $brand-white;
-  border: 2px solid $selected-color;
-  background-color: $selected-color;
+  color: color('primary-1');
+  border: 2px solid color('primary-1');
+  background: color('brand-orange-100');
 
   &:hover {
     cursor: default;
@@ -98,10 +98,15 @@ $brand-white: color('primary-2');
 }
 
 .disabled {
+  color: color('neutral-2');
   background-color: color('neutral-4');
   border: 2px solid color('neutral-4');
   cursor: not-allowed;
   user-select: none;
+
+  .icon path {
+    fill: color('neutral-2');
+  }
 
   &.outline {
     background-color: transparent;

--- a/src/atoms/Color/Colors.md
+++ b/src/atoms/Color/Colors.md
@@ -1,42 +1,56 @@
 Our brand colors:
 
+    // This is just example code to generate the above palette
 
+    const groupBy = require('lodash/groupBy');
+    const partition = require('lodash/partition');
     const styles = require('atoms/Color/colors_map.module.scss');
 
-    function getColorArray() {
-      let all_colors = [[],[],[]];
-      let types = ['neutral', 'primary', 'secondary'];
+    function Colors({ styleNames, groupFn }) {
+      const rows = Object.values(groupBy(styleNames, groupFn));
 
-      for (style in styles) {
-        types.forEach( (type, idx) => {
-          if( style.indexOf(type) >= 0 ) {
-            all_colors[idx].push(
-              <div className={ styles[style] } key={ style }></div>
-            )
-          }
-        })
-      }
-
-      return all_colors;
-    }
-
-    function DisplayExampleColors ( props ) {
       return (
         <div>
           {
-            getColorArray().map(( set, idx ) => {
-              return (
-                <div
-                  className={ styles['color-wrapper'] }
-                  key={ idx }
-                >
-                  { set }
-                </div>
-              )
-            })
+            rows.map((styleNames, idx) =>
+              <div className={styles['color-wrapper']} key={idx}>
+                {
+                  styleNames.map(styleName =>
+                    <div className={styles[styleName]} key={styleName}/>
+                  )
+                }
+              </div>
+            )
           }
         </div>
-      )
+      );
     }
-    <DisplayExampleColors />
 
+    function DisplayExampleColors() {
+      const styleNames = Object.keys(styles);
+      const [brandStyleNames, semanticStyleNames] = partition(
+        styleNames,
+        styleName => styleName.startsWith('brand-')
+      );
+
+      return (
+        <div>
+          <h2>Brand colors</h2>
+          <p>
+            These are the raw color swatches that may be used throughout the design system,
+            devoid of any semantic meaning.
+          </p>
+          <Colors styleNames={brandStyleNames} groupFn={styleName => styleName.split('-')[1]} />
+
+          <h2>Semantic colors</h2>
+          <p>
+            These are specific usages of the brand color swatches above, but with semantic
+            meaning attached, meant to be used in certain specific situations
+            (eg. <code>primary-1</code> for primary CTAs).
+          </p>
+          <Colors styleNames={semanticStyleNames} groupFn={styleName => styleName.split('-')[0]} />
+        </div>
+      );
+    }
+
+    <DisplayExampleColors />

--- a/src/atoms/Color/colors_map.module.scss
+++ b/src/atoms/Color/colors_map.module.scss
@@ -33,9 +33,6 @@
   flex-wrap: wrap;
 }
 
-$color-type-list: 'neutral', 'primary', 'secondary';
-
-
 @keyframes swing {
   0% {
     transform: perspective(0) rotateX(0deg);
@@ -50,30 +47,25 @@ $color-type-list: 'neutral', 'primary', 'secondary';
   }
 }
 
-@each $type in $color-type-list {
-  @for $i from 1 through 8 {
-    @if map-has-key($colors-map, #{$type}-#{$i}) {
+@each $color-key in map-keys($colors-map) {
+  .#{$color-key} {
+    $color: #{map-get($colors-map, #{$color-key})};
+    color: $color;
+    @include color-props($color);
+    border-color: #fff;
+    transform-origin: center top;
 
-      .#{$type}-#{$i} {
-        $color: #{map-get($colors-map, #{$type}-#{$i})};
-        color: $color;
-        @include color-props($color);
-        border-color: #fff;
-        transform-origin: center top;
+    &:before {
+      @include before-props('#{$color-key}');
+    }
 
-        &:before {
-          @include before-props('#{$type}-#{$i}');
-        }
+    &:after {
+      @include after-props($color);
+    }
 
-        &:after {
-          @include after-props($color);
-        }
-
-        &:hover {
-          box-shadow: 0 2px 3px rgba(0,0,0,0.2);
-          animation: swing 400ms cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
-        }
-      }
+    &:hover {
+      box-shadow: 0 2px 3px rgba(0,0,0,0.2);
+      animation: swing 400ms cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
     }
   }
 }

--- a/src/atoms/Element/Readme.md
+++ b/src/atoms/Element/Readme.md
@@ -1,7 +1,7 @@
 ## What is an Element?
 An atomic element is a component which gives you access to standardized color, spacing, typography and font-weight as a component property. This allows you to compose new components with semantic HTML while adhering to the standard/branding of the RCL.
 
-An atomic element will reset it's styled margins, font-size and color.
+An atomic element will reset its styled margins, font-size and color.
 
 ```css
   .element {

--- a/src/atoms/ErrorMessage/error_message.module.scss
+++ b/src/atoms/ErrorMessage/error_message.module.scss
@@ -8,11 +8,11 @@
 }
 
 .warning {
-  color: color('secondary-2');
+  color: color('secondary-1');
 }
 
 .error {
-  color: color('primary-1');
+  color: color('utility-red');
 }
 
 .visible {

--- a/src/atoms/Icon/Readme.md
+++ b/src/atoms/Icon/Readme.md
@@ -18,7 +18,7 @@ _xIcon example with full SVG DOM and css hover:_
 // You can't edit this. Sorry.
 .icon-hover-example {
   svg path {
-    fill: color('secondary-2');
+    fill: color('secondary-1');
     transition: all .3s;
   }
 

--- a/src/atoms/Icon/icons.module.scss
+++ b/src/atoms/Icon/icons.module.scss
@@ -35,7 +35,7 @@
 /* stylelint-disable */
 :global(.icon-hover-example) {
   svg path {
-    fill: color('secondary-2');
+    fill: color('secondary-1');
     transition: all .3s;
   }
 

--- a/src/molecules/AccountIndicator/account_indicator.module.scss
+++ b/src/molecules/AccountIndicator/account_indicator.module.scss
@@ -35,7 +35,7 @@ $default-spacing: rem-calc(16px);
   justify-content: center;
   align-items: center;
 
-  background: color('secondary-2');
+  background: color('secondary-1');
   border-radius: 100%;
   height: rem-calc(32px);
   width: rem-calc(32px);

--- a/src/molecules/AgentCallout/agent_callout.module.scss
+++ b/src/molecules/AgentCallout/agent_callout.module.scss
@@ -20,5 +20,5 @@
   margin: 0 auto;
 
   border-radius: 50%;
-  border: 2px solid color('secondary-2');
+  border: 2px solid color('secondary-1');
 }

--- a/src/molecules/DataRow/data_row.module.scss
+++ b/src/molecules/DataRow/data_row.module.scss
@@ -86,6 +86,6 @@
 
 .highlight {
   .value, .amount {
-    color: color('secondary-2');
+    color: color('secondary-1');
   }
 }

--- a/src/molecules/LockUps/CurrencyAmount/index.js
+++ b/src/molecules/LockUps/CurrencyAmount/index.js
@@ -11,7 +11,7 @@ const CurrencyAmount = (props) => {
       <sup>{curr}</sup>
       <strong>{amount}</strong>
       {' '}
-      { unit && <Text tag='span' className={unitClassName} size={8} font='b' color={highlight ? 'secondary-2' : 'primary-3'}>{ unit }</Text> }
+      { unit && <Text tag='span' className={unitClassName} size={8} font='b' color={highlight ? 'secondary-1' : 'primary-3'}>{ unit }</Text> }
     </Text>
   );
 };

--- a/src/molecules/StepIndicator/step_indicator.module.scss
+++ b/src/molecules/StepIndicator/step_indicator.module.scss
@@ -48,7 +48,7 @@
     width: 100%;
 
     background-size: 200%;
-    background-image: linear-gradient(to right, color('secondary-2') 50%, #ccc 50%);
+    background-image: linear-gradient(to right, color('secondary-1') 50%, #ccc 50%);
     transition: background-position 1s;
     background-position: right;
   }
@@ -73,12 +73,12 @@
 
   &-active {
     background: #fff;
-    border: 2px solid color('secondary-2');
+    border: 2px solid color('secondary-1');
   }
 
   &-completed {
-    background: color('secondary-2');
-    border: 1px solid color('secondary-2');
+    background: color('secondary-1');
+    border: 1px solid color('secondary-1');
   }
 }
 

--- a/src/molecules/StepProgress/step-progress.module.scss
+++ b/src/molecules/StepProgress/step-progress.module.scss
@@ -5,13 +5,13 @@ $item-size:                         rem-calc(40);
 $item-border-width:                 rem-calc(2);
 $item-border-color:                 color('neutral-4');
 $item-background-color:             color('neutral-8');
-$active-item-border-color:          color('secondary-2');
+$active-item-border-color:          color('secondary-1');
 $inactive-item-border-color:        color('neutral-4');
 
 $mobile-color:                      color('neutral-8');
 $mobile-item-background-color:      color('primary-2');
-$mobile-item-border-color:          color('secondary-2');
-$mobile-active-item-border-color:   color('secondary-2');
+$mobile-item-border-color:          color('secondary-1');
+$mobile-active-item-border-color:   color('secondary-1');
 $mobile-inactive-color:             color('primary-3');
 $mobile-inactive-item-border-color: color('neutral-4');
 

--- a/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
+++ b/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
@@ -49,7 +49,7 @@ $gap: ru(.5);
     }
 
     + .checkbox-label:after {
-      box-shadow: 3px 3px 0 0 color('secondary-2');
+      box-shadow: 3px 3px 0 0 color('secondary-1');
     }
   }
 }
@@ -71,7 +71,7 @@ $gap: ru(.5);
 
   transform: rotate(45deg);
   transform-origin: right;
-  box-shadow: 3px 3px 0 0 color('secondary-2');
+  box-shadow: 3px 3px 0 0 color('secondary-1');
   border-radius: 20%;
 
   opacity: 0;

--- a/src/molecules/formfields/CheckboxWrapper/checkbox_wrapper.module.scss
+++ b/src/molecules/formfields/CheckboxWrapper/checkbox_wrapper.module.scss
@@ -50,7 +50,7 @@
 
 /* --  state:focus  -- */
 .focused {
-  border: 1px solid color('secondary-2');
+  border: 1px solid color('secondary-1');
 }
 
 /* --  state:error  -- */

--- a/src/molecules/formfields/FieldGroup/field_group.module.scss
+++ b/src/molecules/formfields/FieldGroup/field_group.module.scss
@@ -25,7 +25,7 @@
 
 /* --  state:focus  -- */
 .focused {
-  border: 1px solid color('secondary-2');
+  border: 1px solid color('secondary-1');
 }
 
 /* --  state:error  -- */

--- a/src/molecules/formfields/RadioField/radio_field.module.scss
+++ b/src/molecules/formfields/RadioField/radio_field.module.scss
@@ -40,7 +40,7 @@ $checked-size: rem-calc(14px);
     width: $checked-size;
     height: $checked-size;
     border-radius: 50%;
-    background-color: color('secondary-2');
+    background-color: color('primary-1');
   }
 
   &.checked {

--- a/src/molecules/formfields/RadioGroup/radio_group.module.scss
+++ b/src/molecules/formfields/RadioGroup/radio_group.module.scss
@@ -35,7 +35,7 @@
 
 /* --  state:focus  -- */
 .focused {
-  border: 1px solid color('secondary-2');
+  border: 1px solid color('secondary-1');
 }
 
 /* --  state:error  -- */

--- a/src/molecules/formfields/ToggleField/index.js
+++ b/src/molecules/formfields/ToggleField/index.js
@@ -22,17 +22,17 @@ const renderChoices = (choices, input) => {
   if (!choices) return null;
 
   const renderChoice = (choice, idx) => {
-    const variantName = () => toBoolean(input.value) === toBoolean(choice.value) ? 'toggle-selected' : 'toggle';  // eslint-disable-line
+    const variantName = toBoolean(input.value) === toBoolean(choice.value) ? 'toggle-selected' : 'toggle';
 
     return (
       <Button
         className={styles['button']}
-        variant={variantName()}
+        variant={variantName}
         key={`toggle-${idx}`}
-        onClick={() => input.onChange(toBoolean(choice.value))}
+        onClick={() => input.onChange && input.onChange(toBoolean(choice.value))}
         value={choice.value}
         {...omit(input, 'value')}
-        onBlur={() => input.onBlur(toBoolean(choice.value))}
+        onBlur={() => input.onBlur && input.onBlur(toBoolean(choice.value))}
       >
         { choice.label }
       </Button>

--- a/src/molecules/formfields/shared/formfields.module.scss
+++ b/src/molecules/formfields/shared/formfields.module.scss
@@ -11,8 +11,8 @@
  */
 
 $border: 1px solid color('neutral-4');
-$focused-border-color: color('secondary-2');
-$field-error-color: color('primary-1');
+$focused-border-color: color('secondary-1');
+$field-error-color: color('utility-red');
 
 // -- Base Style
 %form-field {

--- a/src/organisms/cards/FeaturedPolicyCard/featured_policy_card.module.scss
+++ b/src/organisms/cards/FeaturedPolicyCard/featured_policy_card.module.scss
@@ -50,7 +50,7 @@ $content-margin-top: ru(.5);
       content: '';
       display: block;
       height: $policy-hat-height;
-      background: color('secondary-4');
+      background: color('secondary-3');
       width: 100%;
       top: calc(-#{$policy-hat-height} + -#{$content-margin-top});
       left: 0;

--- a/src/organisms/cards/PlaybackCardWrapper/index.js
+++ b/src/organisms/cards/PlaybackCardWrapper/index.js
@@ -34,7 +34,7 @@ function PlaybackCardWrapper(props) {
         <div className={classnames(styles['logo-wrapper'], styles['playback-wrapper-logo'])}>{logo}</div>
         <Col className={styles['amount']}>
           <CurrencyAmount
-            color='secondary-2'
+            color='secondary-1'
             amount={formattedNumber.toString()}
             unit={unit}
             size={5}

--- a/src/organisms/cards/SimpleFeaturedPolicyCard/featured_policy_card.module.scss
+++ b/src/organisms/cards/SimpleFeaturedPolicyCard/featured_policy_card.module.scss
@@ -12,7 +12,7 @@ $details-link-border: 1px solid #b2b2b2;
   height: 100%;
 
   &.selected {
-    border: 1px solid color('secondary-2');
+    border: 1px solid color('secondary-1');
   }
 
   .details-link {

--- a/src/organisms/cards/SimplePolicyCard/policy_card.module.scss
+++ b/src/organisms/cards/SimplePolicyCard/policy_card.module.scss
@@ -20,7 +20,7 @@ $footer: #f6f6f6;
   display: none;
 
   &.selected {
-    border: 1px solid color('secondary-2');
+    border: 1px solid color('secondary-1');
   }
 }
 

--- a/src/organisms/forms/shared/forms.module.scss
+++ b/src/organisms/forms/shared/forms.module.scss
@@ -30,7 +30,7 @@ $icon-size:        ru(2);
     position: absolute;
     height: 4px;
     width: 100%;
-    border-top: 4px solid color('secondary-2');
+    border-top: 4px solid color('secondary-1');
   }
 
 
@@ -44,7 +44,7 @@ $icon-size:        ru(2);
 }
 
 .hr {
-  background-color: color('secondary-2');
+  background-color: color('secondary-1');
   height: 6px;
   margin: 0 10px;
   padding: 0;


### PR DESCRIPTION
- Update the base color stylesheet to use the new brand colors. Some
cleanup has been done here as well, namely removing duplicates and
unused values.
- In addition to a color palette update, some components' colors were
also updated:
  - Radio buttons should now be the `primary-1`/`brand-orange-400` color
  - Toggle buttons should now have a border of `primary-1` when in the
selected state, and have a pale orange background
  - Error text should be a red color, to differentiate it between the
primary brand color, which had been its old value
  - Disabled buttons should have a darker text (and icon) color, for
readability