### PR TITLE
Fix font import 

### DIFF
--- a/src/assets/stylesheets/base_styles/_typography.scss
+++ b/src/assets/stylesheets/base_styles/_typography.scss
@@ -1,6 +1,6 @@
 @import 'colors';
 
-@import url('https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap);
 
 $font-family-serif: Lora, Georgia, serif;
 $font-family-sans-serif: 'PolicyGenius', Arial, sans-serif;


### PR DESCRIPTION
## Description
Apparently for importing remote urls you need it to not be a string
Fix from: https://stackoverflow.com/questions/26349982/sass-wont-compile-import-google-font-cdn

## Context:
Using v10 athenaeum causes this error:
```
Failed to compile.
./node_modules/athenaeum/lib/assets/styles.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-6-1!./node_modules/postcss-loader/src??postcss!./node_modules/resolve-url-loader??ref--5-oneOf-6-3!./node_modules/sass-loader/dist/cjs.js??ref--5-oneOf-6-4!./node_modules/athenaeum/lib/assets/styles.css)
SassError: URI is missing ')'
        on line 1 of node_modules/athenaeum/lib/assets/styles.css
>> ra:wght@400;700&display=swap);@import url(https://fonts.googleapis.com/css2?
   ------------------------------------------^
   ```