### PR TITLE
Update webpack config ordering to be correct

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -63,9 +63,6 @@ const baseRules = modulesName => [
           }
         },
         {
-          loader: 'resolve-url-loader'
-        },
-        {
           loader: 'sass-loader',
           options: {
             sourceMap: !isProd,
@@ -73,7 +70,10 @@ const baseRules = modulesName => [
             includePaths: [ baseDir ],
             data: "@import 'assets/stylesheets/global';"
           }
-        }
+        },
+        {
+          loader: 'resolve-url-loader'
+        },
       ]
     })
   },


### PR DESCRIPTION
## Description
Incorrect ordering was causing imports to break because of the typography updates.

## Context
https://www.npmjs.com/package/resolve-url-loader
Specifically calls out using after `sass-loader`.