### PR TITLE
MOR-12: Fixing checkboxes & radios

### DIFF
--- a/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
+++ b/src/molecules/formfields/CheckBoxField/checkbox_field.module.scss
@@ -1,4 +1,5 @@
-$size: ru(1);
+$input-height: rem-calc(28px);
+$checkbox-size: ru(1);
 $gap: ru(.5);
 
 .checkbox {
@@ -6,8 +7,8 @@ $gap: ru(.5);
   align-content: center;
   position: relative;
   margin: 0;
-  min-height: $size;
-  padding-left: $size + $gap;
+  min-height: $checkbox-size;
+  padding-left: $checkbox-size + $gap;
   user-select: none;
 
   + .checkbox {
@@ -17,10 +18,10 @@ $gap: ru(.5);
   &:before {
     content: '';
     position: absolute;
-    top: 0;
+    top: ($input-height - $checkbox-size) / 2;
     left: 0;
-    width: $size;
-    height: $size;
+    width: $checkbox-size;
+    height: $checkbox-size;
     border: 1px solid color('neutral-3');
     background-color: color('primary-2');
     overflow: hidden;
@@ -32,8 +33,8 @@ $gap: ru(.5);
   position: absolute;
   top: 0;
   left: 0;
-  width: $size + $gap;
-  height: $size;
+  width: $checkbox-size + $gap;
+  height: $input-height;
   opacity: 0;
   margin: 0;
   cursor: pointer;
@@ -49,7 +50,7 @@ $gap: ru(.5);
     }
 
     + .checkbox-label:after {
-      box-shadow: 3px 3px 0 0 color('secondary-1');
+      box-shadow: 3px 3px 0 0 color('neutral-3');
     }
   }
 }
@@ -59,19 +60,19 @@ $gap: ru(.5);
 }
 
 .checkbox-label:after {
-  $width: $size / 3;
-  $height: $size / 2;
+  $width: $checkbox-size / 3;
+  $height: $checkbox-size / 2;
 
   position: absolute;
   width: $width;
   height: $height;
-  top: $width / 2;
+  top: $width / 2 + ($input-height - $checkbox-size) / 2;
   left: $height / 2;
   margin-left: rem-calc(1px);
 
   transform: rotate(45deg);
   transform-origin: right;
-  box-shadow: 3px 3px 0 0 color('secondary-1');
+  box-shadow: 3px 3px 0 0 color('primary-1');
   border-radius: 20%;
 
   opacity: 0;

--- a/src/molecules/formfields/RadioField/radio_field.module.scss
+++ b/src/molecules/formfields/RadioField/radio_field.module.scss
@@ -1,6 +1,7 @@
-$size: ru(1);
+$input-height: rem-calc(28px);
 $gap: ru(.5);
-$checked-size: rem-calc(14px);
+$radio-size: ru(1);
+$colored-dot-size: rem-calc(14px);
 
 .radio-field {
   @include typography-b-8;
@@ -8,16 +9,16 @@ $checked-size: rem-calc(14px);
   margin: 0;
   display: block;
   position: relative;
-  min-height: $size;
-  padding-left: $size + $gap;
+  min-height: $radio-size;
+  padding-left: $radio-size + $gap;
   user-select: none;
 
   &:before {
     position: absolute;
-    top: (ru(1) - $size) / 2;
+    top: ($input-height - $radio-size) / 2;
     left: 0;
-    width: $size;
-    height: $size;
+    width: $radio-size;
+    height: $radio-size;
     overflow: hidden;
     border: 1px solid color('neutral-3');
     border-radius: 50%;
@@ -35,10 +36,10 @@ $checked-size: rem-calc(14px);
     content: '';
     opacity: 0;
     position: absolute;
-    top: (ru(1) - $size) / 2 + ($size - $checked-size) / 2;
-    left: ($size - $checked-size) / 2;
-    width: $checked-size;
-    height: $checked-size;
+    top: ($input-height - $radio-size) / 2 + ($radio-size - $colored-dot-size) / 2;
+    left: ($radio-size - $colored-dot-size) / 2;
+    width: $colored-dot-size;
+    height: $colored-dot-size;
     border-radius: 50%;
     background-color: color('primary-1');
   }
@@ -59,8 +60,7 @@ $checked-size: rem-calc(14px);
   top: 0;
   left: 0;
   width: 100%;
-  // width: $size + $gap;
-  height: $size;
+  height: $input-height;
   opacity: 0;
   margin: 0;
   cursor: pointer;


### PR DESCRIPTION
- Vertical alignment was off for both radio button inputs and checkbox
inputs after the typography change
- Checkboxes' checked state should be the primary color, they hadn't
been updated when the radio buttons were updated

## Screenshots
### Checkboxes
Fixed vertical alignment & color
**Before**:
![image](https://user-images.githubusercontent.com/6582067/109358096-344bd080-7851-11eb-89c4-0c092c91425a.png)
**After**:
![image](https://user-images.githubusercontent.com/6582067/109358117-3b72de80-7851-11eb-9aa2-07e29d8af6df.png)

### Radio buttons
Fixed vertical alignment
**Before**:
![image](https://user-images.githubusercontent.com/6582067/109358157-4fb6db80-7851-11eb-9b64-433944d80070.png)

**After**:
![image](https://user-images.githubusercontent.com/6582067/109358176-56dde980-7851-11eb-8fc7-03e18e48fbcd.png)
