### PR TITLE
MOR-14: Fixing FormFields' typography

### DIFF
--- a/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
+++ b/src/molecules/formfields/RadioGroup/__tests__/__snapshots__/radio_group.spec.js.snap
@@ -8,12 +8,13 @@ exports[`<RadioGroup /> renders correctly 1`] = `
     onFocus={undefined}
   >
     <div
-      className="label-wrapper"
+      className="header"
     >
       <div
-        className="label"
+        className="label-wrapper"
       >
         <label
+          className="label"
           htmlFor={undefined}
         >
           Test label

--- a/src/molecules/formfields/RadioGroup/index.js
+++ b/src/molecules/formfields/RadioGroup/index.js
@@ -40,10 +40,10 @@ class RadioGroup extends React.Component {
           }}
           onFocus={input && input.onFocus}
         >
-          <div className={styles['label-wrapper']}>
-            <div className={styles['label']}>
+          <div className={styles['header']}>
+            <div className={styles['label-wrapper']}>
               { /* eslint-disable-next-line jsx-a11y/label-has-for */ }
-              <label htmlFor={input.name}>{label}</label>
+              <label htmlFor={input.name} className={styles['label']}>{label}</label>
               { tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon']) }
             </div>
 

--- a/src/molecules/formfields/RadioGroup/radio_group.module.scss
+++ b/src/molecules/formfields/RadioGroup/radio_group.module.scss
@@ -4,16 +4,20 @@
   @extend %form-field;
 }
 
-.label-wrapper {
+.header {
   padding: ru(.5) ru(.75);
-
   border-bottom: 1px solid color('neutral-4');
 }
 
-.label {
-  @include typography-b-8(true);
-
+.label-wrapper {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label {
+  @extend %label;
+  padding: 0;
 }
 
 .field {
@@ -45,6 +49,6 @@
 
 @media #{$tablet} {
   .label {
-    @include typography-b-8(true);
+    @include typography-a-8-bold;
   }
 }

--- a/src/molecules/formfields/SelectField/select_field.module.scss
+++ b/src/molecules/formfields/SelectField/select_field.module.scss
@@ -94,7 +94,7 @@
   color: color('brand-2');
 
   .label {
-    @include typography-b-8(true);
+    @include typography-a-8-bold;
 
     padding: ru(.5) ru(1) 0;
     border: 0;

--- a/src/molecules/formfields/SplitField/split_field.module.scss
+++ b/src/molecules/formfields/SplitField/split_field.module.scss
@@ -13,7 +13,7 @@ $border: 1px solid color('neutral-4');
 }
 
 .label {
-  @include typography-b-8(true);
+  @include typography-a-8-bold;
 
   color: color('primary-3');
   border-bottom: $border;

--- a/src/molecules/formfields/ToggleField/toggle_field.module.scss
+++ b/src/molecules/formfields/ToggleField/toggle_field.module.scss
@@ -17,7 +17,7 @@
 }
 
 .header {
-  @include typography-b-8(true);
+  @include typography-a-8-bold;
   margin-bottom: ru(.5);
 }
 

--- a/src/molecules/formfields/shared/formfields.module.scss
+++ b/src/molecules/formfields/shared/formfields.module.scss
@@ -34,7 +34,7 @@ $field-error-color: color('utility-red');
 
 /* -- Shared Field Elements -- */
 %label {
-  @include typography-b-8(true);
+  @include typography-a-8-bold;
 
   color: color('primary-3');
   position: relative;

--- a/src/molecules/formfields/util/BaseDateField/date_field.module.scss
+++ b/src/molecules/formfields/util/BaseDateField/date_field.module.scss
@@ -13,7 +13,7 @@ $border: 1px solid color('neutral-4');
 }
 
 .label-wrapper {
-  @include typography-b-8(true);
+  @include typography-a-8-bold;
   color: color('primary-3');
   border-bottom: $border;
   position: relative;


### PR DESCRIPTION
- Changing the `label` typography from B10 to A8 in the FormField
variant components.
- Also, fix the tooltip icon for the RadioGroup component, since it
wasn't `space-between`ed like the other input components

### Screenshots
#### Form fields
**Before:**
![image](https://user-images.githubusercontent.com/6582067/109569589-acff9680-7ab6-11eb-86d4-40ab7320c9be.png)

**After:**
![image](https://user-images.githubusercontent.com/6582067/109569557-a3762e80-7ab6-11eb-8dc7-7a4594e31e0d.png)

#### RadioGroup
In addition to fixing the label font, I also fixed the alignment of the tooltip icon
**Before:**
![image](https://user-images.githubusercontent.com/6582067/109569473-804b7f00-7ab6-11eb-96ab-434397448cef.png)

**After:**
![image](https://user-images.githubusercontent.com/6582067/109569492-87728d00-7ab6-11eb-9ebe-729a6b05d7d3.png)
