### PR TITLE
MOR-15: Fixing StepIndicator typography

### DIFF
--- a/src/molecules/StepIndicator/ProgressBarStep.js
+++ b/src/molecules/StepIndicator/ProgressBarStep.js
@@ -85,7 +85,9 @@ export default class ProgressBarStep extends Component {
     return (
       <div className={styles['breadcrumb']} {...this.clickProps()}>
         <div className={classnames(this.textClasses())}>
-          <Text tag='span' size={11} font='a' spaced className={styles['step-title']} {...this.titleProps()}>{ step.text }</Text>
+          <Text tag='span' size={10} font='a' className={styles['step-title']} {...this.titleProps()}>
+            {step.text}
+          </Text>
         </div>
         <div className={classnames(...this.circleWrapperClasses())}>
           <div className={classnames(...this.circleClasses())} />

--- a/src/molecules/StepIndicator/step_indicator.module.scss
+++ b/src/molecules/StepIndicator/step_indicator.module.scss
@@ -82,10 +82,6 @@
   }
 }
 
-.step-title, .active-step {
-  text-transform: uppercase;
-}
-
 .step-subtitle {
   margin-top: rem-calc(32px);
   padding: 0 rem-calc(16px);

--- a/src/molecules/formfields/RadioGroup/Readme.md
+++ b/src/molecules/formfields/RadioGroup/Readme.md
@@ -5,17 +5,13 @@
       constructor(props) {
         super(props);
 
-        this.state = {
-          value: '',
-        };
+        this.state = { value: '' };
 
         this.onChange = this.onChange.bind(this);
       }
 
       onChange(value) {
-        this.setState({
-          value
-        });
+        this.setState({ value });
       }
 
       render() {
@@ -32,20 +28,12 @@
             <RadioField
               label='Burgers'
               radioValue='burgers'
-              input={{
-                name: 'food',
-                value,
-                onChange: this.onChange,
-              }}
+              input={{ name: 'food', value, onChange: this.onChange }}
             />
             <RadioField
               label='Hot Dogs'
               radioValue='dogs'
-              input={{
-                name: 'food',
-                value,
-                onChange: this.onChange,
-              }}
+              input={{ name: 'food', value, onChange: this.onChange }}
             />
           </RadioGroup>
         )
@@ -53,4 +41,43 @@
     }
 
     <RadioGroupExample />
+```
+
+### RadioGroup Example (no label):
+
+```jsx
+    class RadioGroupExampleNoLabel extends React.Component {
+      constructor(props) {
+        super(props);
+    
+        this.state = { value: '' };
+    
+        this.onChange = this.onChange.bind(this);
+      }
+    
+      onChange(value) {
+        this.setState({ value });
+      }
+    
+      render() {
+        const { value } = this.state;
+    
+        return (
+          <RadioGroup meta={{}} input={{}}>
+            <RadioField
+              label='Burgers'
+              radioValue='burgers'
+              input={{ name: 'food', value, onChange: this.onChange }}
+            />
+            <RadioField
+              label='Hot Dogs'
+              radioValue='dogs'
+              input={{ name: 'food', value, onChange: this.onChange }}
+            />
+          </RadioGroup>
+        )
+      }
+    }
+    
+    <RadioGroupExampleNoLabel />
 ```

--- a/src/molecules/formfields/RadioGroup/Readme.md
+++ b/src/molecules/formfields/RadioGroup/Readme.md
@@ -49,19 +49,19 @@
     class RadioGroupExampleNoLabel extends React.Component {
       constructor(props) {
         super(props);
-    
+
         this.state = { value: '' };
-    
+
         this.onChange = this.onChange.bind(this);
       }
-    
+
       onChange(value) {
         this.setState({ value });
       }
-    
+
       render() {
         const { value } = this.state;
-    
+
         return (
           <RadioGroup meta={{}} input={{}}>
             <RadioField
@@ -78,6 +78,6 @@
         )
       }
     }
-    
+
     <RadioGroupExampleNoLabel />
 ```

--- a/src/molecules/formfields/RadioGroup/index.js
+++ b/src/molecules/formfields/RadioGroup/index.js
@@ -40,24 +40,26 @@ class RadioGroup extends React.Component {
           }}
           onFocus={input && input.onFocus}
         >
-          <div className={styles['header']}>
-            <div className={styles['label-wrapper']}>
-              { /* eslint-disable-next-line jsx-a11y/label-has-for */ }
-              <label htmlFor={input.name} className={styles['label']}>{label}</label>
-              { tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon']) }
-            </div>
+          {label && (
+            <div className={styles['header']}>
+              <div className={styles['label-wrapper']}>
+                { /* eslint-disable-next-line jsx-a11y/label-has-for */}
+                <label htmlFor={input.name} className={styles['label']}>{label}</label>
+                {tooltip && renderTooltip(tooltip, styles['tooltip'], styles['tooltip-icon'])}
+              </div>
 
-            {
-              subLabel && (
-                <Text
-                  size={10}
-                  font='b'
-                >
-                  {subLabel}
-                </Text>
-              )
-            }
-          </div>
+              {
+                subLabel && (
+                  <Text
+                    size={10}
+                    font='b'
+                  >
+                    {subLabel}
+                  </Text>
+                )
+              }
+            </div>
+          )}
           {
             React.Children.map(children, (child) => (
               <div className={styles['field']}>


### PR DESCRIPTION
- The text for each Step in the StepIndicator should be "Sentence cased"
rather than "ALL CAPS".
- In addition, don't render the `header` in the `RadioGroup` component
if no `label` is passed. This is better than having consumers reach into
the library and apply `display: none` to rcl classes.

### Screenshots
#### StepIndicator
**Before:**
![image](https://user-images.githubusercontent.com/6582067/109848630-7cd30780-7c1e-11eb-80f2-eff468c3beec.png)

**After:**
![image](https://user-images.githubusercontent.com/6582067/109848672-8492ac00-7c1e-11eb-9ddb-8464675878ab.png)

#### RadioGroup
When a `<RadioGroup>` is rendered without a `label`, it should not render the top section
**Before:**
![image](https://user-images.githubusercontent.com/6582067/109849003-df2c0800-7c1e-11eb-938e-277c227433e5.png)

**After:**
![image](https://user-images.githubusercontent.com/6582067/109849042-ec48f700-7c1e-11eb-93b7-0e7ff066aab4.png)
