### PR TITLE
Allow empty alt text for icons

### DIFF
--- a/src/atoms/Icon/__tests__/icon.spec.js
+++ b/src/atoms/Icon/__tests__/icon.spec.js
@@ -50,4 +50,15 @@ describe('<Icon />', () => {
 
     expect(actual).toMatchSnapshot();
   });
+
+  it('accepts an empty string for alt text', () => {
+    const props = {
+      icon: 'xIcon',
+      alt: ''
+    };
+
+    const wrapper = mount(<Icon {...props} />);
+
+    expect(wrapper.find('img').prop('alt')).toBe('');
+  });
 });

--- a/src/atoms/Icon/index.js
+++ b/src/atoms/Icon/index.js
@@ -102,7 +102,7 @@ class Icon extends React.Component {
             styles.img,
             isLazy && 'lazyload'
           )}
-          alt={alt || sanitizedIcon}
+          alt={alt != null ? alt : sanitizedIcon}
           title={title || sanitizedIcon}
           data-src={isLazy ? src : undefined}
           src={isLazy ? undefined : src}


### PR DESCRIPTION
[LIFE-1342](https://policygenius.atlassian.net/browse/LIFE-1342)

There are circumstances where it is appropriate and [recommended](https://www.w3.org/WAI/tutorials/images/decision-tree/) to provide an empty string for the `alt` attribute on an image tag. Right now, passing an empty string would result in the default behavior of using the icon name.

Instead, the change here allows an empty string to be passed and not overridden. Not providing an `alt` prop or passing `undefined` or `null` will keep the existing default functionality of using the icon name.