### PR TITLE
Soft Fail Snyk Step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
       docker-compose#v3.2.0:
         run: athenaeum-snyk
         config: docker-compose-snyk.yml
-
+    soft_fail: true
 
   - name: ':scsslint:'
     command: yarn lint


### PR DESCRIPTION
Currently Snyk is used only to scan the vulnerabilities in repositories and it is not intended to block the pipelines. We noticed that if there are issues with Snyk API, the scan step fails and the pipeline gets blocked preventing out apps from deploying. To avoid such situations, this PR adds a soft fail to snyk step so that it does not block the pipeline if Snyk scan fails.