### PR TITLE
Add value to checkbox htmlFor and id

### DIFF
--- a/src/molecules/formfields/CheckBoxField/index.js
+++ b/src/molecules/formfields/CheckBoxField/index.js
@@ -13,18 +13,28 @@ class CheckBoxField extends React.Component {
       textColor,
       fieldRef,
     } = this.props;
+    const {
+      name,
+      value
+    } = input;
+
+    let id = `checkbox-${name}`;
+
+    if (value) {
+      id += `-${value}`;
+    }
 
     return (
       <label
         className={styles['checkbox']}
-        htmlFor={`checkbox-${input.name}`}
+        htmlFor={id}
         ref={fieldRef && fieldRef}
       >
         <input
           type='checkbox'
-          id={`checkbox-${input.name}`}
+          id={id}
           className={styles['checkbox-input']}
-          checked={input.value}
+          checked={value}
           {...input}
         />
         <span className={styles['checkbox-label']}>


### PR DESCRIPTION
**Description**

* Add the `value` to the `htmlFor`/`id` props when rendering the `CheckBoxField`

**Context**
In order to make checkboxes unique when supplied a `value` in the input
prop, the component should use that variable when building the
htmlFor/id pairing for the label and input.

This commit adds the `value` prop to the htmlFor/id string if available.