### PR TITLE
upgrade `react-modal` to match Mortar version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react": "^16.2.0",
     "react-inlinesvg": "^0.7.5",
     "react-input-mask": "^0.8.0",
-    "react-modal": "^3.1.6",
+    "react-modal": "^3.14.4",
     "react-showdown": "^1.6.0",
     "react-stickynode": "^1.4.0",
     "react-svg-inline": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9882,13 +9882,13 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-modal@^3.1.6:
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.1.tgz#2a0d6877c9e98f123939ea92d2bb4ad7fa5a17f9"
-  integrity sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==
+react-modal@^3.14.4:
+  version "3.14.4"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.14.4.tgz#2ca7e8e9a180955e5c9508c228b73167c1e6f6a3"
+  integrity sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==
   dependencies:
     exenv "^1.2.0"
-    prop-types "^15.5.10"
+    prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 


### PR DESCRIPTION
Unticketed

Upgrading the `react-modal` version to match the version in Mortar so that consumers who use both Athenaeum and Mortar, only 1 version will be pulled in. Making this change here so that consumers don't need to handle this in their own yarn/npm setup.