### PR TITLE
upgrading semgrep and removing old semgrep files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,14 +11,20 @@ steps:
 
   - wait
 
-  - name: "Run Semgrep Scan"
-    command: "bin/semgrep.sh"
-    timeout_in_minutes: 3
+  - name: ":semgrep: Semgrep"
+    command: semgrep ci
     agents:
       queue: runner
     plugins:
-      docker-compose#v3.7.0:
-        run: athenaeum-semgrep
+    - docker#v3.7.0:
+        image: us.gcr.io/pg-shared-v1/semgrep_ci:latest
+        workdir: /policygenius/anthenaeum
+        environment:
+          - SEMGREP_APP_TOKEN=${SEMGREP_TOKEN}
+          - SEMGREP_REPO_NAME=policygenius/anthenaeum
+          - SEMGREP_BASELINE_REF=main
+          - SEMGREP_REPO_URL=https://github.com/policygenius/anthenaeum
+          - SEMGREP_PR_ID=${BUILDKITE_PULL_REQUEST}
 
   - name: ':scsslint:'
     command: yarn lint

--- a/Dockerfile.semgrep
+++ b/Dockerfile.semgrep
@@ -1,5 +1,0 @@
-FROM us.gcr.io/pg-shared-v1/semgrep_agent:latest
-
-WORKDIR /athenaeum
-
-COPY . .

--- a/bin/semgrep.sh
+++ b/bin/semgrep.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -euxo pipefail 
-semgrep-agent --baseline-ref $(git merge-base main HEAD) --publish-token $SEMGREP_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,10 +38,4 @@ services:
       - BUILDKITE_REPO
       - GITHUB_TOKEN
       - SONAR_LOGIN
-  athenaeum-semgrep:
-    build:
-      context: .
-      dockerfile: Dockerfile.semgrep
-    shm_size: 512M
-    environment:
-      - SEMGREP_TOKEN
+

--- a/semgrep_config.yaml
+++ b/semgrep_config.yaml
@@ -1,1 +1,0 @@
-args: "--baseline-ref main" 


### PR DESCRIPTION
[INFOSEC-1604](https://policygenius.atlassian.net/browse/INFOSEC-1604)
Semgrep is moving away from Semgrep Agent and to Semgrep CI.  This PR moves to Semgrep CI and removes the unnecessary Semgrep Agent files.